### PR TITLE
feat: Stats view with Swift Charts — extractor, format, timeline

### DIFF
--- a/Fetch.xcodeproj/project.pbxproj
+++ b/Fetch.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		B51F6B0FF426EDCB275EDA9B /* PresetEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F66D521F27304FC866DF21 /* PresetEditorView.swift */; };
 		BF4978831B551D7016E5DF7B /* DownloadQueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2204AA8F92B296FE42E112 /* DownloadQueueView.swift */; };
 		CC20404951AB80477EA91C7A /* NewDownloadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4E5FA37B9156D3146D1561 /* NewDownloadView.swift */; };
+		D5B9AFEE091C6D5F3389FF81 /* StatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC91BF95A053821F8DB23D3F /* StatsView.swift */; };
 		E95B726F299DDC86547F81B4 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2015C2DFB9042CD95C78E28 /* NotificationService.swift */; };
 		EED7DA11CD8FA1102C2DD1B3 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F8777C9ABE883DC2DE1A33 /* SettingsView.swift */; };
 		F3FD90290BB6125BD843AE6F /* FormatPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C2623AAB3EB28232466FDDE /* FormatPickerView.swift */; };
@@ -66,6 +67,7 @@
 		CB4BE44D5F65BC39A95ED47F /* FetchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchTests.swift; sourceTree = "<group>"; };
 		D793FA63DCCCCC5C1490FB6F /* Preset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset.swift; sourceTree = "<group>"; };
 		DC349A2094125985259419FA /* FetchTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FetchTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DC91BF95A053821F8DB23D3F /* StatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -121,6 +123,7 @@
 				02F66D521F27304FC866DF21 /* PresetEditorView.swift */,
 				A5F8777C9ABE883DC2DE1A33 /* SettingsView.swift */,
 				03F699F3560CD95002F95A2D /* SidebarView.swift */,
+				DC91BF95A053821F8DB23D3F /* StatsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -263,6 +266,7 @@
 				B51F6B0FF426EDCB275EDA9B /* PresetEditorView.swift in Sources */,
 				EED7DA11CD8FA1102C2DD1B3 /* SettingsView.swift in Sources */,
 				469A19EBEE2928AB5C294D4F /* SidebarView.swift in Sources */,
+				D5B9AFEE091C6D5F3389FF81 /* StatsView.swift in Sources */,
 				8A23B88E7E891442E1235D64 /* YTDLPService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Fetch/Views/ContentView.swift
+++ b/Fetch/Views/ContentView.swift
@@ -21,6 +21,8 @@ struct ContentView: View {
                     DownloadQueueView()
                 case .history:
                     HistoryView()
+                case .stats:
+                    StatsView()
                 case .presets:
                     PresetEditorView()
                 }
@@ -105,6 +107,7 @@ enum SidebarSection: String, Hashable, CaseIterable {
     case newDownload = "New Download"
     case queue = "Queue"
     case history = "History"
+    case stats = "Stats"
     case presets = "Presets"
 
     var icon: String {
@@ -112,6 +115,7 @@ enum SidebarSection: String, Hashable, CaseIterable {
         case .newDownload: "plus.circle"
         case .queue: "arrow.down.circle"
         case .history: "clock"
+        case .stats: "chart.bar.fill"
         case .presets: "slider.horizontal.3"
         }
     }

--- a/Fetch/Views/SidebarView.swift
+++ b/Fetch/Views/SidebarView.swift
@@ -28,6 +28,9 @@ struct SidebarView: View {
 
                 Label(SidebarSection.history.rawValue, systemImage: SidebarSection.history.icon)
                     .tag(SidebarSection.history)
+
+                Label(SidebarSection.stats.rawValue, systemImage: SidebarSection.stats.icon)
+                    .tag(SidebarSection.stats)
             }
 
             Section("Configuration") {

--- a/Fetch/Views/StatsView.swift
+++ b/Fetch/Views/StatsView.swift
@@ -1,0 +1,278 @@
+import SwiftUI
+import SwiftData
+import Charts
+
+struct StatsView: View {
+    @Query(sort: \Download.dateCreated, order: .reverse) private var downloads: [Download]
+
+    var body: some View {
+        Group {
+            if downloads.isEmpty {
+                emptyState
+            } else {
+                statsContent
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: Design.Spacing.lg) {
+            Image(systemName: "chart.bar.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.tertiary)
+                .accessibilityHidden(true)
+
+            Text("No Statistics Yet")
+                .font(.title2.bold())
+                .foregroundStyle(.primary)
+
+            Text("Download some media to see stats")
+                .font(.body)
+                .foregroundStyle(.secondary)
+        }
+        .padding(Design.Spacing.xxl)
+    }
+
+    // MARK: - Stats Content
+
+    private var statsContent: some View {
+        ScrollView {
+            VStack(spacing: Design.Spacing.xl) {
+                summaryCards
+
+                HStack(alignment: .top, spacing: Design.Spacing.lg) {
+                    extractorChart
+                    formatChart
+                }
+
+                timelineChart
+            }
+            .padding(Design.Spacing.xl)
+        }
+    }
+
+    // MARK: - Summary Cards
+
+    private var summaryCards: some View {
+        HStack(spacing: Design.Spacing.lg) {
+            SummaryCard(
+                title: "Total Downloads",
+                value: "\(downloads.count)",
+                icon: "arrow.down.circle.fill",
+                color: .blue
+            )
+
+            SummaryCard(
+                title: "Total Size",
+                value: formattedTotalSize,
+                icon: "externaldrive.fill",
+                color: .purple
+            )
+
+            SummaryCard(
+                title: "Top Extractor",
+                value: topExtractor ?? "N/A",
+                icon: "globe",
+                color: .orange
+            )
+        }
+    }
+
+    // MARK: - Extractor Bar Chart
+
+    private var extractorChart: some View {
+        VStack(alignment: .leading, spacing: Design.Spacing.md) {
+            Text("Downloads by Extractor")
+                .font(.headline)
+
+            Chart(extractorData, id: \.name) { item in
+                BarMark(
+                    x: .value("Downloads", item.count),
+                    y: .value("Extractor", item.name)
+                )
+                .foregroundStyle(Color.accentColor.gradient)
+                .cornerRadius(Design.Radius.micro)
+            }
+            .chartXAxisLabel("Downloads", alignment: .center)
+            .frame(minHeight: max(CGFloat(extractorData.count) * 32, 120))
+        }
+        .cardStyle()
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Format Pie Chart
+
+    private var formatChart: some View {
+        VStack(alignment: .leading, spacing: Design.Spacing.md) {
+            Text("Format Distribution")
+                .font(.headline)
+
+            Chart(formatData, id: \.name) { item in
+                SectorMark(
+                    angle: .value("Count", item.count),
+                    innerRadius: .ratio(0.5),
+                    angularInset: 1.5
+                )
+                .foregroundStyle(by: .value("Format", item.name))
+                .cornerRadius(Design.Radius.micro)
+            }
+            .chartLegend(position: .bottom, spacing: Design.Spacing.sm)
+            .frame(minHeight: 200)
+        }
+        .cardStyle()
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Timeline Line Chart
+
+    private var timelineChart: some View {
+        VStack(alignment: .leading, spacing: Design.Spacing.md) {
+            Text("Downloads Over Time")
+                .font(.headline)
+
+            Text("Last 30 days")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Chart(timelineData, id: \.date) { item in
+                LineMark(
+                    x: .value("Date", item.date, unit: .day),
+                    y: .value("Downloads", item.count)
+                )
+                .foregroundStyle(Color.accentColor)
+                .interpolationMethod(.catmullRom)
+
+                AreaMark(
+                    x: .value("Date", item.date, unit: .day),
+                    y: .value("Downloads", item.count)
+                )
+                .foregroundStyle(Color.accentColor.opacity(0.1).gradient)
+                .interpolationMethod(.catmullRom)
+            }
+            .chartXAxis {
+                AxisMarks(values: .stride(by: .day, count: 7)) { _ in
+                    AxisGridLine()
+                    AxisValueLabel(format: .dateTime.month(.abbreviated).day())
+                }
+            }
+            .frame(height: 200)
+        }
+        .cardStyle()
+    }
+
+    // MARK: - Data Computation
+
+    private var formattedTotalSize: String {
+        let total = downloads.compactMap(\.fileSize).reduce(0, +)
+        guard total > 0 else { return "N/A" }
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: total)
+    }
+
+    private var topExtractor: String? {
+        let grouped = Dictionary(grouping: downloads) { $0.extractor ?? "Unknown" }
+        return grouped.max(by: { $0.value.count < $1.value.count })?.key
+    }
+
+    private var extractorData: [ChartDataPoint] {
+        let grouped = Dictionary(grouping: downloads) { $0.extractor ?? "Unknown" }
+        return grouped.map { ChartDataPoint(name: $0.key, count: $0.value.count) }
+            .sorted { $0.count > $1.count }
+            .prefix(10)
+            .map { $0 }
+    }
+
+    private var formatData: [ChartDataPoint] {
+        let grouped = Dictionary(grouping: downloads) { item -> String in
+            guard let desc = item.formatDescription?.lowercased() else { return "Unknown" }
+            if desc.contains("mp4") { return "MP4" }
+            if desc.contains("webm") { return "WebM" }
+            if desc.contains("mp3") { return "MP3" }
+            if desc.contains("m4a") { return "M4A" }
+            if desc.contains("mkv") { return "MKV" }
+            if desc.contains("opus") { return "Opus" }
+            if desc.contains("flac") { return "FLAC" }
+            if desc.contains("wav") { return "WAV" }
+            return desc.prefix(8).uppercased()
+        }
+        return grouped.map { ChartDataPoint(name: $0.key, count: $0.value.count) }
+            .sorted { $0.count > $1.count }
+    }
+
+    private var timelineData: [TimelineDataPoint] {
+        let calendar = Calendar.current
+        let now = Date()
+        guard let thirtyDaysAgo = calendar.date(byAdding: .day, value: -30, to: now) else {
+            return []
+        }
+
+        let recentDownloads = downloads.filter { $0.dateCreated >= thirtyDaysAgo }
+        let grouped = Dictionary(grouping: recentDownloads) { download -> Date in
+            calendar.startOfDay(for: download.dateCreated)
+        }
+
+        var result: [TimelineDataPoint] = []
+        var current = calendar.startOfDay(for: thirtyDaysAgo)
+        let end = calendar.startOfDay(for: now)
+
+        while current <= end {
+            let count = grouped[current]?.count ?? 0
+            result.append(TimelineDataPoint(date: current, count: count))
+            guard let next = calendar.date(byAdding: .day, value: 1, to: current) else { break }
+            current = next
+        }
+
+        return result
+    }
+}
+
+// MARK: - Data Types
+
+private struct ChartDataPoint: Identifiable {
+    let name: String
+    let count: Int
+    var id: String { name }
+}
+
+private struct TimelineDataPoint: Identifiable {
+    let date: Date
+    let count: Int
+    var id: Date { date }
+}
+
+// MARK: - Summary Card
+
+private struct SummaryCard: View {
+    let title: String
+    let value: String
+    let icon: String
+    let color: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Design.Spacing.sm) {
+            HStack(spacing: Design.Spacing.sm) {
+                Image(systemName: icon)
+                    .font(.title3)
+                    .foregroundStyle(color)
+                    .accessibilityHidden(true)
+
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(value)
+                .font(.title.bold())
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .cardStyle()
+        .accessibilityElement(children: .combine)
+    }
+}


### PR DESCRIPTION
## Summary
- New "Stats" sidebar section with download statistics visualization
- Swift Charts: bar chart (downloads per extractor), pie chart (format distribution), line chart (download timeline)
- Summary cards: total downloads, total size, most-used extractor
- Empty state when no history exists

## Related Issue
Partially addresses #18

## Test Plan
- [x] Build succeeds in worktree
- [ ] Stats view renders with download history data
- [ ] Empty state shows when no downloads exist
- [ ] Charts are interactive and legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)