### PR TITLE
feat: interactive onboarding tutorial + rotating tip banners

### DIFF
--- a/Fetch.xcodeproj/project.pbxproj
+++ b/Fetch.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		014950E33F4A647CEBFF455E /* AuroraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295A40290D9CAEFC8E428801 /* AuroraView.swift */; };
+		2165D1FD7509CD7D0B03D34B /* TipBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7827C9F6121D8E7248BFB6F0 /* TipBanner.swift */; };
 		3493B290393BF124FD3FCD9F /* DownloadRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810C9DED2B14FB17EFA4529A /* DownloadRowView.swift */; };
 		430DE1CBFBCAFB4760DA4655 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B850F5B3805294E911C842 /* ContentView.swift */; };
 		469A19EBEE2928AB5C294D4F /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F699F3560CD95002F95A2D /* SidebarView.swift */; };
@@ -20,6 +21,7 @@
 		8A23B88E7E891442E1235D64 /* YTDLPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50FE8D8EB834FCF61AD11C6 /* YTDLPService.swift */; };
 		91A342B625E57B799CACE111 /* ClipboardMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603D7BFBF85B8544C708F910 /* ClipboardMonitor.swift */; };
 		99CE97D28A4692EBA98EAD8F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 176D1E2BC292A264EFB80D97 /* Assets.xcassets */; };
+		AD1529C23B56930C1344ECF8 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A794F31E255F800586B666AB /* OnboardingView.swift */; };
 		B51F6B0FF426EDCB275EDA9B /* PresetEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F66D521F27304FC866DF21 /* PresetEditorView.swift */; };
 		BF4978831B551D7016E5DF7B /* DownloadQueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2204AA8F92B296FE42E112 /* DownloadQueueView.swift */; };
 		CC20404951AB80477EA91C7A /* NewDownloadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4E5FA37B9156D3146D1561 /* NewDownloadView.swift */; };
@@ -57,10 +59,12 @@
 		4D5AD7256382F628128A1A8F /* FetchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchApp.swift; sourceTree = "<group>"; };
 		603D7BFBF85B8544C708F910 /* ClipboardMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardMonitor.swift; sourceTree = "<group>"; };
 		6C2623AAB3EB28232466FDDE /* FormatPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatPickerView.swift; sourceTree = "<group>"; };
+		7827C9F6121D8E7248BFB6F0 /* TipBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipBanner.swift; sourceTree = "<group>"; };
 		7FDB1C316F100F78CCBAD1B1 /* Download.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Download.swift; sourceTree = "<group>"; };
 		810C9DED2B14FB17EFA4529A /* DownloadRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadRowView.swift; sourceTree = "<group>"; };
 		8E96BAC29AB9C3CE3DAC8C30 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		A5F8777C9ABE883DC2DE1A33 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		A794F31E255F800586B666AB /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		B2015C2DFB9042CD95C78E28 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		BE17EB2ADCBD3436D999E2DC /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
 		C50FE8D8EB834FCF61AD11C6 /* YTDLPService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YTDLPService.swift; sourceTree = "<group>"; };
@@ -120,10 +124,12 @@
 				6C2623AAB3EB28232466FDDE /* FormatPickerView.swift */,
 				BE17EB2ADCBD3436D999E2DC /* HistoryView.swift */,
 				3A4E5FA37B9156D3146D1561 /* NewDownloadView.swift */,
+				A794F31E255F800586B666AB /* OnboardingView.swift */,
 				02F66D521F27304FC866DF21 /* PresetEditorView.swift */,
 				A5F8777C9ABE883DC2DE1A33 /* SettingsView.swift */,
 				03F699F3560CD95002F95A2D /* SidebarView.swift */,
 				DC91BF95A053821F8DB23D3F /* StatsView.swift */,
+				7827C9F6121D8E7248BFB6F0 /* TipBanner.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -262,11 +268,13 @@
 				5F89860AE5866DDA04D7D767 /* HistoryView.swift in Sources */,
 				CC20404951AB80477EA91C7A /* NewDownloadView.swift in Sources */,
 				E95B726F299DDC86547F81B4 /* NotificationService.swift in Sources */,
+				AD1529C23B56930C1344ECF8 /* OnboardingView.swift in Sources */,
 				782C0E06D94E3E88CB598E15 /* Preset.swift in Sources */,
 				B51F6B0FF426EDCB275EDA9B /* PresetEditorView.swift in Sources */,
 				EED7DA11CD8FA1102C2DD1B3 /* SettingsView.swift in Sources */,
 				469A19EBEE2928AB5C294D4F /* SidebarView.swift in Sources */,
 				D5B9AFEE091C6D5F3389FF81 /* StatsView.swift in Sources */,
+				2165D1FD7509CD7D0B03D34B /* TipBanner.swift in Sources */,
 				8A23B88E7E891442E1235D64 /* YTDLPService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Fetch/FetchApp.swift
+++ b/Fetch/FetchApp.swift
@@ -4,6 +4,8 @@ import SwiftData
 @main
 struct FetchApp: App {
     @State private var downloadManager = DownloadManager()
+    @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
+    @State private var showOnboarding = false
     @Environment(\.openWindow) private var openWindow
 
     init() {
@@ -17,6 +19,14 @@ struct FetchApp: App {
                 .onReceive(NotificationCenter.default.publisher(for: NSApplication.willTerminateNotification)) { _ in
                     downloadManager.cancelAll()
                 }
+                .onAppear {
+                    if !hasCompletedOnboarding {
+                        showOnboarding = true
+                    }
+                }
+                .sheet(isPresented: $showOnboarding) {
+                    OnboardingView(isPresented: $showOnboarding)
+                }
         }
         .modelContainer(for: [Download.self, Preset.self])
         .defaultSize(width: 900, height: 600)
@@ -26,6 +36,11 @@ struct FetchApp: App {
                     NSApp.activate()
                 }
                 .keyboardShortcut("n")
+            }
+            CommandGroup(replacing: .help) {
+                Button("Welcome to Fetch...") {
+                    showOnboarding = true
+                }
             }
         }
 

--- a/Fetch/Views/DownloadQueueView.swift
+++ b/Fetch/Views/DownloadQueueView.swift
@@ -6,11 +6,15 @@ struct DownloadQueueView: View {
     var body: some View {
         Group {
             if manager.activeTasks.isEmpty {
-                ContentUnavailableView(
-                    "No Downloads",
-                    systemImage: "arrow.down.circle.dashed",
-                    description: Text("Start a download from the New Download tab or paste a URL.")
-                )
+                VStack(spacing: Design.Spacing.xl) {
+                    ContentUnavailableView(
+                        "No Downloads",
+                        systemImage: "arrow.down.circle.dashed",
+                        description: Text("Start a download from the New Download tab or paste a URL.")
+                    )
+                    TipBanner()
+                        .padding(.horizontal, Design.Spacing.xxl)
+                }
             } else {
                 List {
                     ForEach(manager.activeTasks) { task in

--- a/Fetch/Views/OnboardingView.swift
+++ b/Fetch/Views/OnboardingView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+
+// MARK: - Onboarding View
+
+struct OnboardingView: View {
+    @Binding var isPresented: Bool
+    @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
+    @State private var currentStep = 0
+
+    private let steps = OnboardingStep.allSteps
+
+    var body: some View {
+        VStack(spacing: 0) {
+            TabView(selection: $currentStep) {
+                ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
+                    OnboardingStepView(step: step)
+                        .tag(index)
+                }
+            }
+            .tabViewStyle(.automatic)
+            .frame(width: 520, height: 380)
+
+            // MARK: - Navigation
+
+            HStack {
+                if currentStep > 0 {
+                    Button("Back") {
+                        withAnimation { currentStep -= 1 }
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                // Step indicators
+                HStack(spacing: Design.Spacing.sm) {
+                    ForEach(0..<steps.count, id: \.self) { index in
+                        Circle()
+                            .fill(index == currentStep ? Color.accentColor : Color.secondary.opacity(0.3))
+                            .frame(width: 7, height: 7)
+                            .scaleEffect(index == currentStep ? 1.2 : 1.0)
+                            .animation(.spring(duration: 0.25), value: currentStep)
+                    }
+                }
+
+                Spacer()
+
+                if currentStep < steps.count - 1 {
+                    Button("Next") {
+                        withAnimation { currentStep += 1 }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                } else {
+                    Button("Get Started") {
+                        hasCompletedOnboarding = true
+                        isPresented = false
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                }
+            }
+            .padding(.horizontal, Design.Spacing.xl)
+            .padding(.bottom, Design.Spacing.xl)
+        }
+        .frame(width: 520, height: 440)
+    }
+}
+
+// MARK: - Onboarding Step Model
+
+private struct OnboardingStep {
+    let title: String
+    let description: String
+    let icon: String
+    let features: [FeatureItem]
+
+    struct FeatureItem {
+        let icon: String
+        let text: String
+    }
+
+    static let allSteps: [OnboardingStep] = [
+        OnboardingStep(
+            title: "Welcome to Fetch",
+            description: "A powerful, native macOS frontend for yt-dlp.\nDownload video and audio from 1,800+ sites\nwith a clean, intuitive interface.",
+            icon: "arrow.down.circle.fill",
+            features: []
+        ),
+        OnboardingStep(
+            title: "Paste or Drop",
+            description: "Getting started is simple. Paste a URL, drag-and-drop a link, or let Fetch detect URLs from your clipboard automatically.",
+            icon: "doc.on.clipboard",
+            features: [
+                FeatureItem(icon: "link.badge.plus", text: "Paste any supported URL to start"),
+                FeatureItem(icon: "arrow.down.doc", text: "Drag and drop links directly"),
+                FeatureItem(icon: "eye", text: "Automatic clipboard URL detection"),
+            ]
+        ),
+        OnboardingStep(
+            title: "Choose Your Format",
+            description: "Pick exactly the format you want, or let Fetch choose the best quality automatically.",
+            icon: "slider.horizontal.3",
+            features: [
+                FeatureItem(icon: "film", text: "Browse all available video and audio formats"),
+                FeatureItem(icon: "star", text: "Save presets for repeated workflows"),
+                FeatureItem(icon: "gearshape.2", text: "Advanced options for fine-grained control"),
+            ]
+        ),
+        OnboardingStep(
+            title: "Power Features",
+            description: "Go beyond basic downloads with tools built for power users.",
+            icon: "bolt.fill",
+            features: [
+                FeatureItem(icon: "forward.end.alt", text: "SponsorBlock: skip sponsor segments automatically"),
+                FeatureItem(icon: "captions.bubble", text: "Download subtitles for AI text analysis"),
+                FeatureItem(icon: "square.and.arrow.down.on.square", text: "Batch downloads for playlists and channels"),
+                FeatureItem(icon: "keyboard", text: "Cmd+N new download, Cmd+Shift+V paste & fetch"),
+            ]
+        ),
+    ]
+}
+
+// MARK: - Step View
+
+private struct OnboardingStepView: View {
+    let step: OnboardingStep
+
+    var body: some View {
+        VStack(spacing: Design.Spacing.lg) {
+            Spacer()
+
+            Image(systemName: step.icon)
+                .font(.system(size: 48))
+                .foregroundStyle(Color.accentColor)
+                .symbolRenderingMode(.hierarchical)
+                .accessibilityHidden(true)
+
+            Text(step.title)
+                .font(.title.bold())
+                .multilineTextAlignment(.center)
+
+            Text(step.description)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .lineSpacing(4)
+                .frame(maxWidth: 380)
+
+            if !step.features.isEmpty {
+                VStack(alignment: .leading, spacing: Design.Spacing.md) {
+                    ForEach(Array(step.features.enumerated()), id: \.offset) { _, feature in
+                        HStack(spacing: Design.Spacing.md) {
+                            Image(systemName: feature.icon)
+                                .font(.body)
+                                .foregroundStyle(Color.accentColor)
+                                .frame(width: 20)
+                                .accessibilityHidden(true)
+                            Text(feature.text)
+                                .font(.callout)
+                        }
+                    }
+                }
+                .padding(.top, Design.Spacing.sm)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, Design.Spacing.xl)
+    }
+}

--- a/Fetch/Views/TipBanner.swift
+++ b/Fetch/Views/TipBanner.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+// MARK: - Tip Banner
+
+/// A rotating tip banner for empty states that cycles through helpful hints.
+struct TipBanner: View {
+    @State private var currentTipIndex = 0
+    @State private var timer: Timer?
+    @State private var isVisible = true
+
+    private static let tips: [String] = [
+        "Did you know? Fetch supports 1,800+ sites via yt-dlp.",
+        "Tip: Use Cmd+Shift+V to paste and fetch in one step.",
+        "Try SponsorBlock to automatically skip sponsor segments.",
+        "Download subtitles for AI text analysis with Advanced Options.",
+        "Save your favorite settings as presets for one-click downloads.",
+        "Drag and drop URLs directly into Fetch to start downloading.",
+        "Fetch auto-detects URLs copied to your clipboard.",
+    ]
+
+    var body: some View {
+        HStack(spacing: Design.Spacing.md) {
+            Image(systemName: "lightbulb.fill")
+                .font(.callout)
+                .foregroundStyle(.yellow)
+                .accessibilityHidden(true)
+
+            Text(Self.tips[currentTipIndex])
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .id(currentTipIndex) // force transition on change
+                .transition(.opacity)
+        }
+        .padding(.horizontal, Design.Spacing.lg)
+        .padding(.vertical, Design.Spacing.md)
+        .glassBackground()
+        .animation(.easeInOut(duration: 0.5), value: currentTipIndex)
+        .onAppear { startTimer() }
+        .onDisappear { stopTimer() }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func startTimer() {
+        timer = Timer.scheduledTimer(withTimeInterval: 8.0, repeats: true) { _ in
+            Task { @MainActor in
+                currentTipIndex = (currentTipIndex + 1) % Self.tips.count
+            }
+        }
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+}


### PR DESCRIPTION
## Summary
- 4-step onboarding walkthrough on first launch (Welcome, Paste/Drop, Formats, Power Features)
- TabView with custom page dots navigation
- @AppStorage persistence — shows once, re-accessible from Help menu
- TipBanner component with rotating tips every 8 seconds in empty queue state

## Related Issue
Partially addresses #19

## Test Plan
- [x] Build succeeds in worktree
- [ ] First launch shows onboarding sheet
- [ ] Subsequent launches skip onboarding
- [ ] Tips rotate in empty queue state
- [ ] Help menu can re-trigger onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)