### PR TITLE
feat: batch URL support — multi-line input, file drop, smart parsing

### DIFF
--- a/Fetch.xcodeproj/project.pbxproj
+++ b/Fetch.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		014950E33F4A647CEBFF455E /* AuroraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295A40290D9CAEFC8E428801 /* AuroraView.swift */; };
 		2165D1FD7509CD7D0B03D34B /* TipBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7827C9F6121D8E7248BFB6F0 /* TipBanner.swift */; };
 		3493B290393BF124FD3FCD9F /* DownloadRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810C9DED2B14FB17EFA4529A /* DownloadRowView.swift */; };
+		3EB84EE80BE3BC1E29AA4922 /* URLParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D903C6575F2CB42F5F65E8 /* URLParser.swift */; };
 		430DE1CBFBCAFB4760DA4655 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B850F5B3805294E911C842 /* ContentView.swift */; };
 		469A19EBEE2928AB5C294D4F /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F699F3560CD95002F95A2D /* SidebarView.swift */; };
 		4E4407DB8D0EFC532B5E1B05 /* Download.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FDB1C316F100F78CCBAD1B1 /* Download.swift */; };
@@ -59,6 +60,7 @@
 		4D5AD7256382F628128A1A8F /* FetchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchApp.swift; sourceTree = "<group>"; };
 		603D7BFBF85B8544C708F910 /* ClipboardMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardMonitor.swift; sourceTree = "<group>"; };
 		6C2623AAB3EB28232466FDDE /* FormatPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatPickerView.swift; sourceTree = "<group>"; };
+		76D903C6575F2CB42F5F65E8 /* URLParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLParser.swift; sourceTree = "<group>"; };
 		7827C9F6121D8E7248BFB6F0 /* TipBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipBanner.swift; sourceTree = "<group>"; };
 		7FDB1C316F100F78CCBAD1B1 /* Download.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Download.swift; sourceTree = "<group>"; };
 		810C9DED2B14FB17EFA4529A /* DownloadRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadRowView.swift; sourceTree = "<group>"; };
@@ -91,6 +93,7 @@
 				603D7BFBF85B8544C708F910 /* ClipboardMonitor.swift */,
 				2CC7AD15C637CADA0824F35E /* DownloadManager.swift */,
 				B2015C2DFB9042CD95C78E28 /* NotificationService.swift */,
+				76D903C6575F2CB42F5F65E8 /* URLParser.swift */,
 				C50FE8D8EB834FCF61AD11C6 /* YTDLPService.swift */,
 			);
 			path = Services;
@@ -275,6 +278,7 @@
 				469A19EBEE2928AB5C294D4F /* SidebarView.swift in Sources */,
 				D5B9AFEE091C6D5F3389FF81 /* StatsView.swift in Sources */,
 				2165D1FD7509CD7D0B03D34B /* TipBanner.swift in Sources */,
+				3EB84EE80BE3BC1E29AA4922 /* URLParser.swift in Sources */,
 				8A23B88E7E891442E1235D64 /* YTDLPService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Fetch/Services/URLParser.swift
+++ b/Fetch/Services/URLParser.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Intelligently extracts URLs from any text format: plain text, JSON arrays, CSV, mixed content.
+enum URLParser {
+
+    /// Extract all valid http/https URLs from arbitrary text input.
+    /// Handles: one-per-line, JSON arrays, CSV, mixed prose, and file contents.
+    static func extractURLs(from text: String) -> [String] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        var urls: [String] = []
+
+        // Try JSON array first: ["url1", "url2", ...]
+        if trimmed.hasPrefix("[") {
+            if let data = trimmed.data(using: .utf8),
+               let jsonArray = try? JSONSerialization.jsonObject(with: data) as? [String] {
+                urls = jsonArray.compactMap { validateURL($0) }
+                if !urls.isEmpty { return deduplicate(urls) }
+            }
+            // Also try JSON array of objects with "url" key
+            if let data = trimmed.data(using: .utf8),
+               let jsonArray = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
+                urls = jsonArray.compactMap { dict in
+                    (dict["url"] as? String).flatMap { validateURL($0) }
+                }
+                if !urls.isEmpty { return deduplicate(urls) }
+            }
+        }
+
+        // Regex extraction: find all http/https URLs in arbitrary text
+        let pattern = #"https?://[^\s<>\"\'\]\)\},]+"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return []
+        }
+
+        let nsText = text as NSString
+        let matches = regex.matches(in: text, range: NSRange(location: 0, length: nsText.length))
+
+        for match in matches {
+            let urlString = nsText.substring(with: match.range)
+            // Clean trailing punctuation that may have been captured
+            let cleaned = urlString
+                .trimmingCharacters(in: CharacterSet(charactersIn: ".,;:!?)]}"))
+            if let valid = validateURL(cleaned) {
+                urls.append(valid)
+            }
+        }
+
+        return deduplicate(urls)
+    }
+
+    /// Extract URLs from a file at the given path. Supports .txt, .json, .csv.
+    static func extractURLs(fromFileAt path: String) -> [String] {
+        guard let data = FileManager.default.contents(atPath: path),
+              let text = String(data: data, encoding: .utf8)
+        else { return [] }
+        return extractURLs(from: text)
+    }
+
+    /// Validate that a string is a well-formed http/https URL.
+    private static func validateURL(_ string: String) -> String? {
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmed),
+              let scheme = url.scheme,
+              ["http", "https"].contains(scheme),
+              url.host != nil
+        else { return nil }
+        return trimmed
+    }
+
+    /// Remove duplicates while preserving order.
+    private static func deduplicate(_ urls: [String]) -> [String] {
+        var seen = Set<String>()
+        return urls.filter { url in
+            let normalized = url.lowercased()
+            guard !seen.contains(normalized) else { return false }
+            seen.insert(normalized)
+            return true
+        }
+    }
+}

--- a/Fetch/Views/NewDownloadView.swift
+++ b/Fetch/Views/NewDownloadView.swift
@@ -18,6 +18,9 @@ struct NewDownloadView: View {
     @State private var showFormatPicker = false
     @State private var isDropTargeted = false
     @State private var fetchTask: Task<Void, Never>?
+    @State private var batchMode = false
+    @State private var batchURLs: [String] = []
+    @State private var batchSelected: Set<String> = []
 
     // Advanced options
     @State private var downloadSubtitles = false
@@ -59,34 +62,137 @@ struct NewDownloadView: View {
 
     private var urlInputSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("URL")
-                .font(.headline)
+            HStack {
+                Text("URL")
+                    .font(.headline)
+                Spacer()
+                Toggle("Batch Mode", isOn: $batchMode)
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                    .help("Paste multiple URLs — one per line, JSON array, or drop a text file")
+            }
 
-            HStack(spacing: 8) {
-                TextField("Paste or drop a video/audio URL...", text: $urlText)
-                    .textFieldStyle(.roundedBorder)
-                    .onSubmit { fetchInfo() }
-
-                Button("Paste") {
-                    if let content = NSPasteboard.general.string(forType: .string) {
-                        urlText = content.trimmingCharacters(in: .whitespacesAndNewlines)
-                        fetchInfo()
-                    }
-                }
-                .keyboardShortcut("v", modifiers: [.command, .shift])
-
-                Button("Fetch") { fetchInfo() }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(urlText.isEmpty || isLoading)
+            if batchMode {
+                batchInputView
+            } else {
+                singleURLInput
             }
         }
         .padding(isDropTargeted ? 4 : 0)
         .overlay(
             RoundedRectangle(cornerRadius: 8)
-                .strokeBorder(.blue, lineWidth: isDropTargeted ? 2 : 0)
+                .strokeBorder(Color.accentColor, lineWidth: isDropTargeted ? 2 : 0)
         )
-        .onDrop(of: [.url, .plainText], isTargeted: $isDropTargeted) { providers in
+        .onDrop(of: [.url, .plainText, .fileURL], isTargeted: $isDropTargeted) { providers in
             handleDrop(providers)
+        }
+    }
+
+    private var singleURLInput: some View {
+        HStack(spacing: 8) {
+            TextField("Paste or drop a video/audio URL...", text: $urlText)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit { fetchInfo() }
+
+            Button("Paste") {
+                if let content = NSPasteboard.general.string(forType: .string) {
+                    let urls = URLParser.extractURLs(from: content)
+                    if urls.count > 1 {
+                        batchMode = true
+                        batchURLs = urls
+                        batchSelected = Set(urls)
+                    } else {
+                        urlText = content.trimmingCharacters(in: .whitespacesAndNewlines)
+                        fetchInfo()
+                    }
+                }
+            }
+            .keyboardShortcut("v", modifiers: [.command, .shift])
+
+            Button("Fetch") { fetchInfo() }
+                .buttonStyle(.borderedProminent)
+                .disabled(urlText.isEmpty || isLoading)
+        }
+    }
+
+    private var batchInputView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            TextEditor(text: $urlText)
+                .font(.body.monospaced())
+                .frame(minHeight: 80, maxHeight: 150)
+                .border(Color.secondary.opacity(0.2))
+                .overlay(alignment: .topLeading) {
+                    if urlText.isEmpty {
+                        Text("Paste URLs — one per line, JSON array, or mixed text...")
+                            .font(.body.monospaced())
+                            .foregroundStyle(.tertiary)
+                            .padding(6)
+                            .allowsHitTesting(false)
+                    }
+                }
+
+            HStack {
+                Button("Parse URLs") {
+                    let parsed = URLParser.extractURLs(from: urlText)
+                    batchURLs = parsed
+                    batchSelected = Set(parsed)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(urlText.isEmpty)
+
+                Button("Paste from Clipboard") {
+                    if let content = NSPasteboard.general.string(forType: .string) {
+                        urlText = content
+                        let parsed = URLParser.extractURLs(from: content)
+                        batchURLs = parsed
+                        batchSelected = Set(parsed)
+                    }
+                }
+
+                Spacer()
+
+                if !batchURLs.isEmpty {
+                    Text("\(batchURLs.count) URLs found, \(batchSelected.count) selected")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if !batchURLs.isEmpty {
+                VStack(spacing: 0) {
+                    HStack {
+                        Button("Select All") { batchSelected = Set(batchURLs) }
+                        Button("Deselect All") { batchSelected.removeAll() }
+                        Spacer()
+                        Button("Download \(batchSelected.count) URLs") {
+                            startBatchDownload()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(batchSelected.isEmpty)
+                    }
+                    .font(.caption)
+                    .padding(.bottom, 4)
+
+                    List {
+                        ForEach(batchURLs, id: \.self) { url in
+                            Toggle(isOn: Binding(
+                                get: { batchSelected.contains(url) },
+                                set: { isOn in
+                                    if isOn { batchSelected.insert(url) }
+                                    else { batchSelected.remove(url) }
+                                }
+                            )) {
+                                Text(url)
+                                    .font(.caption.monospaced())
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            }
+                        }
+                    }
+                    .listStyle(.bordered)
+                    .frame(maxHeight: 200)
+                }
+            }
         }
     }
 
@@ -341,23 +447,39 @@ struct NewDownloadView: View {
                 }
                 return true
             }
+            // File drop support (.txt, .json, .csv)
+            if provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) {
+                provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier) { item, _ in
+                    guard let data = item as? Data,
+                          let fileURL = URL(dataRepresentation: data, relativeTo: nil) else { return }
+                    let urls = URLParser.extractURLs(fromFileAt: fileURL.path)
+                    if !urls.isEmpty {
+                        Task { @MainActor in
+                            batchMode = true
+                            batchURLs = urls
+                            batchSelected = Set(urls)
+                        }
+                    }
+                }
+                return true
+            }
             if provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) {
                 provider.loadItem(forTypeIdentifier: UTType.plainText.identifier) { item, _ in
-                    if let text = item as? String {
-                        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                        if trimmed.hasPrefix("http://") || trimmed.hasPrefix("https://") {
-                            Task { @MainActor in
-                                urlText = trimmed
-                                fetchInfo()
-                            }
+                    let text: String? = if let s = item as? String { s }
+                        else if let d = item as? Data { String(data: d, encoding: .utf8) }
+                        else { nil }
+                    guard let text else { return }
+                    let urls = URLParser.extractURLs(from: text)
+                    if urls.count > 1 {
+                        Task { @MainActor in
+                            batchMode = true
+                            batchURLs = urls
+                            batchSelected = Set(urls)
                         }
-                    } else if let data = item as? Data, let text = String(data: data, encoding: .utf8) {
-                        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                        if trimmed.hasPrefix("http://") || trimmed.hasPrefix("https://") {
-                            Task { @MainActor in
-                                urlText = trimmed
-                                fetchInfo()
-                            }
+                    } else if let single = urls.first {
+                        Task { @MainActor in
+                            urlText = single
+                            fetchInfo()
                         }
                     }
                 }
@@ -425,6 +547,37 @@ struct NewDownloadView: View {
         urlText = ""
         self.mediaInfo = nil
         selectedFormat = nil
+    }
+
+    private func startBatchDownload() {
+        for url in batchURLs where batchSelected.contains(url) {
+            manager.enqueue(
+                url: url,
+                title: url,
+                formatId: nil,
+                additionalArgs: buildAdvancedArgs()
+            )
+        }
+        // Reset
+        urlText = ""
+        batchURLs = []
+        batchSelected = []
+        batchMode = false
+    }
+
+    private func buildAdvancedArgs() -> [String] {
+        var args: [String] = []
+        if downloadSubtitles {
+            args += autoGeneratedSubs ? ["--write-auto-subs"] : ["--write-subs"]
+            if embedSubtitles { args += ["--embed-subs"] }
+            args += ["--sub-langs", "en.*,en"]
+        }
+        if embedThumbnail { args += ["--embed-thumbnail"] }
+        if embedMetadata { args += ["--embed-metadata"] }
+        if sponsorBlock { args += ["--sponsorblock-remove", "all"] }
+        if !speedLimit.isEmpty { args += ["--limit-rate", speedLimit] }
+        if !cookiesBrowser.isEmpty { args += ["--cookies-from-browser", cookiesBrowser] }
+        return args
     }
 
     // MARK: - Contextual Suggestions


### PR DESCRIPTION
## Summary
- Smart URL parser (JSON, plain text, mixed content, file drops)
- Batch mode toggle with multi-line TextEditor
- Parsed URL list with checkboxes for selective download
- Auto-detects multiple URLs in clipboard paste

## Related Issue
Partially addresses #10

## Test Plan
- [x] Build succeeds, 7/7 tests pass
- [ ] Paste 5 URLs → batch mode activates, all 5 parsed
- [ ] Paste JSON array → URLs extracted
- [ ] Drop .txt file with URLs → batch list populated
- [ ] Single URL paste → normal mode, fetches info

🤖 Generated with [Claude Code](https://claude.com/claude-code)