### PR TITLE
fix: prevent onboarding sheet from dismissing on outside click

### DIFF
--- a/Fetch/FetchApp.swift
+++ b/Fetch/FetchApp.swift
@@ -26,6 +26,7 @@ struct FetchApp: App {
                 }
                 .sheet(isPresented: $showOnboarding) {
                     OnboardingView(isPresented: $showOnboarding)
+                        .interactiveDismissDisabled()
                 }
         }
         .modelContainer(for: [Download.self, Preset.self])


### PR DESCRIPTION
## Summary
Add `.interactiveDismissDisabled()` to onboarding sheet. Users must complete all 4 steps.

## Related Issue
Closes #25

## Test Plan
- [x] Build succeeds, 7/7 tests pass
- [ ] Fresh launch: sheet cannot be dismissed by clicking outside
- [ ] Must click through all 4 steps to dismiss
- [ ] Help → Welcome to Fetch re-opens onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)