### PR TITLE
fix: onboarding buttons respond to Return key

### DIFF
--- a/Fetch/Views/OnboardingView.swift
+++ b/Fetch/Views/OnboardingView.swift
@@ -52,6 +52,7 @@ struct OnboardingView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
+                    .keyboardShortcut(.defaultAction)
                 } else {
                     Button("Get Started") {
                         hasCompletedOnboarding = true
@@ -59,6 +60,7 @@ struct OnboardingView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
+                    .keyboardShortcut(.defaultAction)
                 }
             }
             .padding(.horizontal, Design.Spacing.xl)


### PR DESCRIPTION
## Summary
Add `.keyboardShortcut(.defaultAction)` to Next and Get Started buttons.

Closes #27

## Test Plan
- [x] Build + 7/7 tests
- [ ] Return key advances through all 4 onboarding steps
- [ ] Return on step 4 completes onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)