### PR TITLE
fix: add Skip button to onboarding, allow dismiss

### DIFF
--- a/Fetch/FetchApp.swift
+++ b/Fetch/FetchApp.swift
@@ -24,9 +24,10 @@ struct FetchApp: App {
                         showOnboarding = true
                     }
                 }
-                .sheet(isPresented: $showOnboarding) {
+                .sheet(isPresented: $showOnboarding, onDismiss: {
+                    hasCompletedOnboarding = true
+                }) {
                     OnboardingView(isPresented: $showOnboarding)
-                        .interactiveDismissDisabled()
                 }
         }
         .modelContainer(for: [Download.self, Preset.self])

--- a/Fetch/Views/OnboardingView.swift
+++ b/Fetch/Views/OnboardingView.swift
@@ -29,6 +29,14 @@ struct OnboardingView: View {
                     }
                     .buttonStyle(.plain)
                     .foregroundStyle(.secondary)
+                } else {
+                    Button("Skip") {
+                        hasCompletedOnboarding = true
+                        isPresented = false
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
                 }
 
                 Spacer()


### PR DESCRIPTION
## Summary
- Skip button on step 1 for users who don't want the walkthrough
- Sheet dismissable by clicking outside (marks onboarding complete)
- Three exit paths: Skip, click outside, complete all 4 steps

## Test Plan
- [x] Build + 7/7 tests
- [ ] Skip on step 1 dismisses and doesn't re-show
- [ ] Click outside dismisses and doesn't re-show
- [ ] Completing all 4 steps still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)