### PR TITLE
fix: populate fileSize from disk in saveToHistory

### DIFF
--- a/Fetch/Services/DownloadManager.swift
+++ b/Fetch/Services/DownloadManager.swift
@@ -235,13 +235,21 @@ final class DownloadManager {
         guard !savedTaskIDs.contains(task.id) else { return }
         savedTaskIDs.insert(task.id)
 
+        // Get actual file size from disk
+        var fileSize: Int64?
+        if let path = task.outputPath {
+            let attrs = try? FileManager.default.attributesOfItem(atPath: path)
+            fileSize = attrs?[.size] as? Int64
+        }
+
         let download = Download(
             url: task.url,
             title: task.title ?? task.url,
             status: .completed,
             formatId: task.formatId,
-            formatDescription: task.formatDescription,
+            formatDescription: task.formatDescription ?? task.formatId,
             outputPath: task.outputPath,
+            fileSize: fileSize,
             thumbnailURL: task.thumbnailURL,
             extractor: task.extractor,
             duration: task.duration


### PR DESCRIPTION
## Summary
- Get file size from disk after download completes
- Fall back to formatId for formatDescription
- Stats "Total Size" card now shows real data

Closes #29

## Test Plan
- [x] Build + 7/7 tests
- [ ] Download a video → History shows file size
- [ ] Stats "Total Size" shows cumulative bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)