### PR TITLE
feat: Media Library view — catalog, sort, filter, file tracking

### DIFF
--- a/Fetch.xcodeproj/project.pbxproj
+++ b/Fetch.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		014950E33F4A647CEBFF455E /* AuroraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 295A40290D9CAEFC8E428801 /* AuroraView.swift */; };
+		1C1E80509C7308DC859BE10C /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57781422AA02941E7974B42F /* LibraryView.swift */; };
 		2165D1FD7509CD7D0B03D34B /* TipBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7827C9F6121D8E7248BFB6F0 /* TipBanner.swift */; };
 		3493B290393BF124FD3FCD9F /* DownloadRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810C9DED2B14FB17EFA4529A /* DownloadRowView.swift */; };
 		3EB84EE80BE3BC1E29AA4922 /* URLParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76D903C6575F2CB42F5F65E8 /* URLParser.swift */; };
@@ -58,6 +59,7 @@
 		3D2E05E552D27BF453B59CF0 /* FormatOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatOption.swift; sourceTree = "<group>"; };
 		3EA8633828937CB26FFECA19 /* Fetch.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Fetch.entitlements; sourceTree = "<group>"; };
 		4D5AD7256382F628128A1A8F /* FetchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchApp.swift; sourceTree = "<group>"; };
+		57781422AA02941E7974B42F /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
 		603D7BFBF85B8544C708F910 /* ClipboardMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardMonitor.swift; sourceTree = "<group>"; };
 		6C2623AAB3EB28232466FDDE /* FormatPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatPickerView.swift; sourceTree = "<group>"; };
 		76D903C6575F2CB42F5F65E8 /* URLParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLParser.swift; sourceTree = "<group>"; };
@@ -126,6 +128,7 @@
 				810C9DED2B14FB17EFA4529A /* DownloadRowView.swift */,
 				6C2623AAB3EB28232466FDDE /* FormatPickerView.swift */,
 				BE17EB2ADCBD3436D999E2DC /* HistoryView.swift */,
+				57781422AA02941E7974B42F /* LibraryView.swift */,
 				3A4E5FA37B9156D3146D1561 /* NewDownloadView.swift */,
 				A794F31E255F800586B666AB /* OnboardingView.swift */,
 				02F66D521F27304FC866DF21 /* PresetEditorView.swift */,
@@ -269,6 +272,7 @@
 				FEB0B42D3F7AAE255FBB13E6 /* FormatOption.swift in Sources */,
 				F3FD90290BB6125BD843AE6F /* FormatPickerView.swift in Sources */,
 				5F89860AE5866DDA04D7D767 /* HistoryView.swift in Sources */,
+				1C1E80509C7308DC859BE10C /* LibraryView.swift in Sources */,
 				CC20404951AB80477EA91C7A /* NewDownloadView.swift in Sources */,
 				E95B726F299DDC86547F81B4 /* NotificationService.swift in Sources */,
 				AD1529C23B56930C1344ECF8 /* OnboardingView.swift in Sources */,

--- a/Fetch/Views/ContentView.swift
+++ b/Fetch/Views/ContentView.swift
@@ -21,6 +21,8 @@ struct ContentView: View {
                     DownloadQueueView()
                 case .history:
                     HistoryView()
+                case .library:
+                    LibraryView()
                 case .stats:
                     StatsView()
                 case .presets:
@@ -107,6 +109,7 @@ enum SidebarSection: String, Hashable, CaseIterable {
     case newDownload = "New Download"
     case queue = "Queue"
     case history = "History"
+    case library = "Library"
     case stats = "Stats"
     case presets = "Presets"
 
@@ -115,6 +118,7 @@ enum SidebarSection: String, Hashable, CaseIterable {
         case .newDownload: "plus.circle"
         case .queue: "arrow.down.circle"
         case .history: "clock"
+        case .library: "books.vertical.fill"
         case .stats: "chart.bar.fill"
         case .presets: "slider.horizontal.3"
         }

--- a/Fetch/Views/LibraryView.swift
+++ b/Fetch/Views/LibraryView.swift
@@ -1,0 +1,523 @@
+import SwiftUI
+import SwiftData
+
+struct LibraryView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Query(
+        filter: #Predicate<Download> { $0.status == "completed" },
+        sort: \Download.dateCreated,
+        order: .reverse
+    ) private var downloads: [Download]
+
+    @State private var searchText = ""
+    @State private var sortOrder: LibrarySortOrder = .date
+    @State private var filterExtractor: String? = nil
+    @State private var filterFileStatus: FileStatusFilter = .all
+    @State private var filterFormatType: FormatTypeFilter = .all
+    @State private var viewMode: ViewMode = .list
+    @State private var fileExistsCache: [String: Bool] = [:]
+
+    // MARK: - Body
+
+    var body: some View {
+        Group {
+            if downloads.isEmpty {
+                ContentUnavailableView(
+                    "No Media",
+                    systemImage: "photo.on.rectangle",
+                    description: Text("Downloaded media will appear in your library.")
+                )
+            } else if filteredAndSorted.isEmpty {
+                ContentUnavailableView(
+                    "No Results",
+                    systemImage: "magnifyingglass",
+                    description: Text("No media matches your current filters.")
+                )
+            } else {
+                switch viewMode {
+                case .list:
+                    listView
+                case .grid:
+                    gridView
+                }
+            }
+        }
+        .navigationTitle("Library")
+        .searchable(text: $searchText, prompt: "Search library...")
+        .toolbar { toolbarContent }
+        .task { await checkAllFileExistence() }
+    }
+
+    // MARK: - List View
+
+    private var listView: some View {
+        List(filteredAndSorted) { download in
+            LibraryRowView(
+                download: download,
+                fileExists: fileExistsCache[download.outputPath ?? ""] ?? true
+            )
+            .contextMenu { contextMenuItems(for: download) }
+        }
+        .listStyle(.inset(alternatesRowBackgrounds: true))
+    }
+
+    // MARK: - Grid View
+
+    private var gridView: some View {
+        ScrollView {
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 180, maximum: 240), spacing: Design.Spacing.md)],
+                spacing: Design.Spacing.md
+            ) {
+                ForEach(filteredAndSorted) { download in
+                    LibraryGridItemView(
+                        download: download,
+                        fileExists: fileExistsCache[download.outputPath ?? ""] ?? true
+                    )
+                    .contextMenu { contextMenuItems(for: download) }
+                }
+            }
+            .padding(Design.Spacing.lg)
+        }
+    }
+
+    // MARK: - Toolbar
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItemGroup {
+            Picker("View", selection: $viewMode) {
+                Image(systemName: "list.bullet")
+                    .tag(ViewMode.list)
+                    .accessibilityLabel("List view")
+                Image(systemName: "square.grid.2x2")
+                    .tag(ViewMode.grid)
+                    .accessibilityLabel("Grid view")
+            }
+            .pickerStyle(.segmented)
+            .accessibilityLabel("View mode")
+
+            Menu {
+                Picker("Sort By", selection: $sortOrder) {
+                    ForEach(LibrarySortOrder.allCases, id: \.self) { order in
+                        Text(order.label).tag(order)
+                    }
+                }
+
+                Divider()
+
+                Menu("Extractor") {
+                    Button("All") { filterExtractor = nil }
+                    Divider()
+                    ForEach(availableExtractors, id: \.self) { extractor in
+                        Button(extractor) { filterExtractor = extractor }
+                    }
+                }
+
+                Menu("Format") {
+                    ForEach(FormatTypeFilter.allCases, id: \.self) { filter in
+                        Button(filter.label) { filterFormatType = filter }
+                    }
+                }
+
+                Menu("File Status") {
+                    ForEach(FileStatusFilter.allCases, id: \.self) { filter in
+                        Button(filter.label) { filterFileStatus = filter }
+                    }
+                }
+
+                if hasActiveFilters {
+                    Divider()
+                    Button("Clear Filters") { clearFilters() }
+                }
+            } label: {
+                Label("Filter & Sort", systemImage: hasActiveFilters ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
+            }
+            .accessibilityLabel("Filter and sort options")
+
+            Text("\(filteredAndSorted.count) items")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .monospacedDigit()
+        }
+    }
+
+    // MARK: - Context Menu
+
+    @ViewBuilder
+    private func contextMenuItems(for download: Download) -> some View {
+        if let path = download.outputPath {
+            let exists = fileExistsCache[path] ?? true
+            if exists {
+                Button("Open") {
+                    NSWorkspace.shared.open(URL(fileURLWithPath: path))
+                }
+                Button("Show in Finder") {
+                    NSWorkspace.shared.selectFile(path, inFileViewerRootedAtPath: "")
+                }
+                Divider()
+            }
+        }
+
+        Button("Copy URL") {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(download.url, forType: .string)
+        }
+
+        Divider()
+
+        Button("Delete from Library", role: .destructive) {
+            modelContext.delete(download)
+        }
+    }
+
+    // MARK: - Filtering & Sorting
+
+    private var filteredAndSorted: [Download] {
+        var result = downloads
+
+        // Search
+        if !searchText.isEmpty {
+            let query = searchText.lowercased()
+            result = result.filter {
+                $0.title.lowercased().contains(query)
+                || $0.url.lowercased().contains(query)
+                || ($0.extractor?.lowercased().contains(query) ?? false)
+                || ($0.formatDescription?.lowercased().contains(query) ?? false)
+            }
+        }
+
+        // Filter: extractor
+        if let filterExtractor {
+            result = result.filter { $0.extractor == filterExtractor }
+        }
+
+        // Filter: format type
+        switch filterFormatType {
+        case .all:
+            break
+        case .video:
+            result = result.filter { download in
+                guard let desc = download.formatDescription?.lowercased() else { return false }
+                return desc.contains("video") || desc.contains("mp4") || desc.contains("webm")
+                    || desc.contains("mkv") || desc.contains("avi") || desc.contains("mov")
+            }
+        case .audio:
+            result = result.filter { download in
+                guard let desc = download.formatDescription?.lowercased() else { return false }
+                return desc.contains("audio") || desc.contains("mp3") || desc.contains("m4a")
+                    || desc.contains("opus") || desc.contains("flac") || desc.contains("wav")
+                    || desc.contains("aac")
+            }
+        }
+
+        // Filter: file status
+        switch filterFileStatus {
+        case .all:
+            break
+        case .exists:
+            result = result.filter { fileExistsCache[$0.outputPath ?? ""] ?? false }
+        case .missing:
+            result = result.filter { !(fileExistsCache[$0.outputPath ?? ""] ?? true) }
+        }
+
+        // Sort
+        switch sortOrder {
+        case .date:
+            break // already sorted by @Query
+        case .title:
+            result.sort { $0.title.localizedStandardCompare($1.title) == .orderedAscending }
+        case .size:
+            result.sort { ($0.fileSize ?? 0) > ($1.fileSize ?? 0) }
+        case .extractor:
+            result.sort { ($0.extractor ?? "").localizedStandardCompare($1.extractor ?? "") == .orderedAscending }
+        }
+
+        return result
+    }
+
+    private var availableExtractors: [String] {
+        let extractors = Set(downloads.compactMap(\.extractor))
+        return extractors.sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+    }
+
+    private var hasActiveFilters: Bool {
+        filterExtractor != nil || filterFileStatus != .all || filterFormatType != .all
+    }
+
+    private func clearFilters() {
+        filterExtractor = nil
+        filterFileStatus = .all
+        filterFormatType = .all
+    }
+
+    // MARK: - File Existence
+
+    private func checkAllFileExistence() async {
+        let paths = downloads.compactMap(\.outputPath)
+        let results = await Task.detached {
+            var map: [String: Bool] = [:]
+            for path in paths {
+                map[path] = FileManager.default.fileExists(atPath: path)
+            }
+            return map
+        }.value
+        fileExistsCache = results
+    }
+}
+
+// MARK: - Library Row View
+
+struct LibraryRowView: View {
+    let download: Download
+    let fileExists: Bool
+
+    var body: some View {
+        HStack(spacing: Design.Spacing.md) {
+            thumbnailView
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(download.title)
+                    .font(.callout.weight(.semibold))
+                    .lineLimit(1)
+                    .tracking(-0.2)
+                    .opacity(fileExists ? 1.0 : 0.5)
+
+                HStack(spacing: 6) {
+                    if let extractor = download.extractor {
+                        Text(extractor)
+                            .font(.caption)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(.quaternary, in: Capsule())
+                    }
+
+                    if let format = download.formatDescription {
+                        Text(format)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if let duration = download.formattedDuration {
+                        Label(duration, systemImage: "clock")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if let size = download.formattedFileSize {
+                        Text(size)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if !fileExists {
+                        Label("File missing", systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+                }
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(download.dateCreated, style: .relative)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 6)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityDescription)
+    }
+
+    // MARK: - Thumbnail
+
+    @ViewBuilder
+    private var thumbnailView: some View {
+        if let thumbStr = download.thumbnailURL, let url = URL(string: thumbStr) {
+            AsyncImage(url: url) { image in
+                image.resizable().aspectRatio(contentMode: .fill)
+            } placeholder: {
+                thumbnailPlaceholder
+            }
+            .frame(width: 56, height: 34)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .accessibilityHidden(true)
+            .overlay(alignment: .bottomTrailing) {
+                if !fileExists {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.orange)
+                        .offset(x: 4, y: 4)
+                        .accessibilityHidden(true)
+                }
+            }
+        } else {
+            Image(systemName: "doc.fill")
+                .foregroundStyle(.secondary)
+                .font(.title3)
+                .frame(width: 56)
+                .accessibilityHidden(true)
+        }
+    }
+
+    private var thumbnailPlaceholder: some View {
+        RoundedRectangle(cornerRadius: 6)
+            .fill(.quaternary)
+            .overlay {
+                Image(systemName: "photo")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+    }
+
+    private var accessibilityDescription: String {
+        var parts = [download.title]
+        if let extractor = download.extractor { parts.append(extractor) }
+        if let duration = download.formattedDuration { parts.append(duration) }
+        if let size = download.formattedFileSize { parts.append(size) }
+        if !fileExists { parts.append("file missing") }
+        return parts.joined(separator: ", ")
+    }
+}
+
+// MARK: - Library Grid Item View
+
+struct LibraryGridItemView: View {
+    let download: Download
+    let fileExists: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Design.Spacing.sm) {
+            // Thumbnail
+            ZStack(alignment: .bottomTrailing) {
+                if let thumbStr = download.thumbnailURL, let url = URL(string: thumbStr) {
+                    AsyncImage(url: url) { image in
+                        image.resizable().aspectRatio(16/9, contentMode: .fill)
+                    } placeholder: {
+                        gridThumbnailPlaceholder
+                    }
+                } else {
+                    gridThumbnailPlaceholder
+                }
+
+                if let duration = download.formattedDuration {
+                    Text(duration)
+                        .font(.caption2.bold())
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 2)
+                        .background(.black.opacity(0.7), in: RoundedRectangle(cornerRadius: 4))
+                        .foregroundStyle(.white)
+                        .padding(Design.Spacing.xs)
+                }
+            }
+            .frame(height: 110)
+            .clipShape(RoundedRectangle(cornerRadius: Design.Radius.standard))
+            .overlay {
+                if !fileExists {
+                    RoundedRectangle(cornerRadius: Design.Radius.standard)
+                        .fill(.black.opacity(0.3))
+                        .overlay {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                                .font(.title3)
+                        }
+                }
+            }
+
+            // Info
+            VStack(alignment: .leading, spacing: 2) {
+                Text(download.title)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(2)
+                    .opacity(fileExists ? 1.0 : 0.5)
+
+                HStack(spacing: 4) {
+                    if let extractor = download.extractor {
+                        Text(extractor)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    if let size = download.formattedFileSize {
+                        Text(size)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityDescription)
+    }
+
+    private var gridThumbnailPlaceholder: some View {
+        Rectangle()
+            .fill(.quaternary)
+            .aspectRatio(16/9, contentMode: .fill)
+            .overlay {
+                Image(systemName: "photo")
+                    .font(.title3)
+                    .foregroundStyle(.tertiary)
+            }
+    }
+
+    private var accessibilityDescription: String {
+        var parts = [download.title]
+        if let extractor = download.extractor { parts.append(extractor) }
+        if let duration = download.formattedDuration { parts.append(duration) }
+        if !fileExists { parts.append("file missing") }
+        return parts.joined(separator: ", ")
+    }
+}
+
+// MARK: - Supporting Types
+
+enum ViewMode: String, CaseIterable {
+    case list
+    case grid
+}
+
+enum LibrarySortOrder: String, CaseIterable {
+    case date
+    case title
+    case size
+    case extractor
+
+    var label: String {
+        switch self {
+        case .date: "Date"
+        case .title: "Title"
+        case .size: "Size"
+        case .extractor: "Extractor"
+        }
+    }
+}
+
+enum FileStatusFilter: String, CaseIterable {
+    case all
+    case exists
+    case missing
+
+    var label: String {
+        switch self {
+        case .all: "All"
+        case .exists: "On Disk"
+        case .missing: "Missing"
+        }
+    }
+}
+
+enum FormatTypeFilter: String, CaseIterable {
+    case all
+    case video
+    case audio
+
+    var label: String {
+        switch self {
+        case .all: "All"
+        case .video: "Video"
+        case .audio: "Audio"
+        }
+    }
+}

--- a/Fetch/Views/SidebarView.swift
+++ b/Fetch/Views/SidebarView.swift
@@ -29,6 +29,9 @@ struct SidebarView: View {
                 Label(SidebarSection.history.rawValue, systemImage: SidebarSection.history.icon)
                     .tag(SidebarSection.history)
 
+                Label(SidebarSection.library.rawValue, systemImage: SidebarSection.library.icon)
+                    .tag(SidebarSection.library)
+
                 Label(SidebarSection.stats.rawValue, systemImage: SidebarSection.stats.icon)
                     .tag(SidebarSection.stats)
             }


### PR DESCRIPTION
## Summary
New "Library" sidebar section for browsing all downloaded media:
- List/grid toggle, sort by date/title/size/extractor
- Filter by extractor, format type, file exists/missing
- Search bar, thumbnails, file existence tracking
- Context menus: Open, Show in Finder, Copy URL, Delete

Partially addresses #17

## Test Plan
- [x] Build succeeds in worktree
- [ ] Library shows all downloaded media with thumbnails
- [ ] Sort and filter work correctly
- [ ] File-missing indicator appears for deleted files
- [ ] Context menu actions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)