### PR TITLE
feat: playlist detection, enumeration, and organized downloads

### DIFF
--- a/Fetch.xcodeproj/project.pbxproj
+++ b/Fetch.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		77A54975BD430DB4BB3E14AA /* FetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4BE44D5F65BC39A95ED47F /* FetchTests.swift */; };
 		782C0E06D94E3E88CB598E15 /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = D793FA63DCCCCC5C1490FB6F /* Preset.swift */; };
 		7AA6B1CEF42D4B149257F77C /* DownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC7AD15C637CADA0824F35E /* DownloadManager.swift */; };
+		7F508C340D4B58672F164D85 /* PlaylistPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C200474128D92F86539CE26 /* PlaylistPickerView.swift */; };
 		8A23B88E7E891442E1235D64 /* YTDLPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50FE8D8EB834FCF61AD11C6 /* YTDLPService.swift */; };
 		91A342B625E57B799CACE111 /* ClipboardMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603D7BFBF85B8544C708F910 /* ClipboardMonitor.swift */; };
 		99CE97D28A4692EBA98EAD8F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 176D1E2BC292A264EFB80D97 /* Assets.xcassets */; };
@@ -53,6 +54,7 @@
 		176D1E2BC292A264EFB80D97 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1FBA7AF4F9DBED4D305D007C /* Fetch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Fetch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		295A40290D9CAEFC8E428801 /* AuroraView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuroraView.swift; sourceTree = "<group>"; };
+		2C200474128D92F86539CE26 /* PlaylistPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistPickerView.swift; sourceTree = "<group>"; };
 		2C9A73C0BB961790EBB0D9B3 /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
 		2CC7AD15C637CADA0824F35E /* DownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownloadManager.swift; sourceTree = "<group>"; };
 		3A4E5FA37B9156D3146D1561 /* NewDownloadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewDownloadView.swift; sourceTree = "<group>"; };
@@ -134,6 +136,7 @@
 				57781422AA02941E7974B42F /* LibraryView.swift */,
 				3A4E5FA37B9156D3146D1561 /* NewDownloadView.swift */,
 				A794F31E255F800586B666AB /* OnboardingView.swift */,
+				2C200474128D92F86539CE26 /* PlaylistPickerView.swift */,
 				02F66D521F27304FC866DF21 /* PresetEditorView.swift */,
 				A5F8777C9ABE883DC2DE1A33 /* SettingsView.swift */,
 				03F699F3560CD95002F95A2D /* SidebarView.swift */,
@@ -280,6 +283,7 @@
 				CC20404951AB80477EA91C7A /* NewDownloadView.swift in Sources */,
 				E95B726F299DDC86547F81B4 /* NotificationService.swift in Sources */,
 				AD1529C23B56930C1344ECF8 /* OnboardingView.swift in Sources */,
+				7F508C340D4B58672F164D85 /* PlaylistPickerView.swift in Sources */,
 				782C0E06D94E3E88CB598E15 /* Preset.swift in Sources */,
 				B51F6B0FF426EDCB275EDA9B /* PresetEditorView.swift in Sources */,
 				EED7DA11CD8FA1102C2DD1B3 /* SettingsView.swift in Sources */,

--- a/Fetch/Models/Download.swift
+++ b/Fetch/Models/Download.swift
@@ -17,6 +17,11 @@ final class Download {
     var dateCompleted: Date?
     var errorMessage: String?
 
+    // Playlist / Collection grouping
+    var playlistTitle: String?
+    var playlistIndex: Int?
+    var playlistId: String?
+
     init(
         url: String,
         title: String,
@@ -27,7 +32,10 @@ final class Download {
         fileSize: Int64? = nil,
         thumbnailURL: String? = nil,
         extractor: String? = nil,
-        duration: Double? = nil
+        duration: Double? = nil,
+        playlistTitle: String? = nil,
+        playlistIndex: Int? = nil,
+        playlistId: String? = nil
     ) {
         self.url = url
         self.title = title
@@ -39,6 +47,9 @@ final class Download {
         self.thumbnailURL = thumbnailURL
         self.extractor = extractor
         self.duration = duration
+        self.playlistTitle = playlistTitle
+        self.playlistIndex = playlistIndex
+        self.playlistId = playlistId
         self.dateCreated = Date()
     }
 

--- a/Fetch/Models/FormatOption.swift
+++ b/Fetch/Models/FormatOption.swift
@@ -126,6 +126,35 @@ struct MediaInfo: Sendable {
     }
 }
 
+// MARK: - Playlist Types
+
+struct PlaylistInfo: Sendable {
+    let title: String
+    let id: String?
+    let uploader: String?
+    let entries: [PlaylistEntry]
+    let url: String
+
+    var totalDuration: TimeInterval? {
+        let durations = entries.compactMap(\.duration)
+        return durations.isEmpty ? nil : durations.reduce(0, +)
+    }
+}
+
+struct PlaylistEntry: Identifiable, Sendable {
+    let url: String
+    let title: String
+    let duration: TimeInterval?
+    let thumbnailURL: URL?
+    let index: Int
+
+    var id: String { url }
+
+    var formattedDuration: String? {
+        duration.flatMap { DurationFormatter.format($0) }
+    }
+}
+
 // MARK: - Shared Utilities
 
 enum DurationFormatter {

--- a/Fetch/Services/DownloadManager.swift
+++ b/Fetch/Services/DownloadManager.swift
@@ -61,6 +61,10 @@ final class DownloadManager {
         try await service.listExtractors()
     }
 
+    func fetchPlaylistInfo(for url: String) async throws -> PlaylistInfo? {
+        try await service.getPlaylistInfo(for: url)
+    }
+
     // MARK: - Download Queue
 
     func enqueue(
@@ -72,22 +76,37 @@ final class DownloadManager {
         additionalArgs: [String] = [],
         thumbnailURL: String? = nil,
         extractor: String? = nil,
-        duration: Double? = nil
+        duration: Double? = nil,
+        playlistTitle: String? = nil,
+        playlistIndex: Int? = nil,
+        playlistId: String? = nil
     ) {
         var combinedArgs = preset?.asArguments() ?? []
         combinedArgs += additionalArgs
+
+        // Playlist downloads go to a subfolder
+        let outputDir: String
+        if let playlistTitle {
+            let safeTitle = playlistTitle.replacingOccurrences(of: "/", with: "-")
+            outputDir = (preset?.outputDirectory ?? defaultOutputDirectory) + "/\(safeTitle)"
+        } else {
+            outputDir = preset?.outputDirectory ?? defaultOutputDirectory
+        }
 
         let task = DownloadTask(
             url: url,
             title: title,
             formatId: formatId,
             formatDescription: formatDescription,
-            outputDirectory: preset?.outputDirectory ?? defaultOutputDirectory,
+            outputDirectory: outputDir,
             outputTemplate: preset?.outputTemplate ?? "%(title)s.%(ext)s",
             extraArgs: combinedArgs,
             thumbnailURL: thumbnailURL,
             extractor: extractor,
-            duration: duration
+            duration: duration,
+            playlistTitle: playlistTitle,
+            playlistIndex: playlistIndex,
+            playlistId: playlistId
         )
 
         activeTasks.append(task)
@@ -252,7 +271,10 @@ final class DownloadManager {
             fileSize: fileSize,
             thumbnailURL: task.thumbnailURL,
             extractor: task.extractor,
-            duration: task.duration
+            duration: task.duration,
+            playlistTitle: task.playlistTitle,
+            playlistIndex: task.playlistIndex,
+            playlistId: task.playlistId
         )
         context.insert(download)
         try? context.save()
@@ -273,6 +295,9 @@ final class DownloadTask: Identifiable, @unchecked Sendable {
     let thumbnailURL: String?
     let extractor: String?
     let duration: Double?
+    let playlistTitle: String?
+    let playlistIndex: Int?
+    let playlistId: String?
     let dateCreated = Date()
 
     var title: String?
@@ -295,7 +320,10 @@ final class DownloadTask: Identifiable, @unchecked Sendable {
         extraArgs: [String],
         thumbnailURL: String? = nil,
         extractor: String? = nil,
-        duration: Double? = nil
+        duration: Double? = nil,
+        playlistTitle: String? = nil,
+        playlistIndex: Int? = nil,
+        playlistId: String? = nil
     ) {
         self.url = url
         self.title = title
@@ -307,6 +335,9 @@ final class DownloadTask: Identifiable, @unchecked Sendable {
         self.thumbnailURL = thumbnailURL
         self.extractor = extractor
         self.duration = duration
+        self.playlistTitle = playlistTitle
+        self.playlistIndex = playlistIndex
+        self.playlistId = playlistId
     }
 
     enum DownloadTaskStatus: String {

--- a/Fetch/Services/YTDLPService.swift
+++ b/Fetch/Services/YTDLPService.swift
@@ -58,6 +58,64 @@ actor YTDLPService {
         return MediaInfo(json: json, url: url)
     }
 
+    // MARK: - Playlist
+
+    /// Detect whether a URL is a playlist and enumerate its entries.
+    /// Returns nil if the URL is a single video (not a playlist).
+    func getPlaylistInfo(for url: String) async throws -> PlaylistInfo? {
+        let bin = try await findBinary()
+        let result = try await shell(bin, [
+            "--flat-playlist",
+            "--dump-json",
+            "--no-download",
+            "--no-warnings",
+            url,
+        ])
+
+        // --flat-playlist --dump-json outputs one JSON object per line
+        let lines = result.output.components(separatedBy: .newlines).filter { !$0.isEmpty }
+        guard lines.count > 1 else { return nil } // single video, not a playlist
+
+        var entries: [PlaylistEntry] = []
+        var playlistTitle: String?
+        var playlistId: String?
+        var playlistUploader: String?
+
+        for (index, line) in lines.enumerated() {
+            guard let data = line.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { continue }
+
+            // Extract playlist metadata from first entry
+            if index == 0 {
+                playlistTitle = json["playlist_title"] as? String ?? json["playlist"] as? String
+                playlistId = json["playlist_id"] as? String
+                playlistUploader = json["playlist_uploader"] as? String
+            }
+
+            let entry = PlaylistEntry(
+                url: json["url"] as? String ?? json["webpage_url"] as? String ?? "",
+                title: json["title"] as? String ?? "Entry \(index + 1)",
+                duration: json["duration"] as? TimeInterval,
+                thumbnailURL: (json["thumbnail"] as? String).flatMap { URL(string: $0) },
+                index: index + 1
+            )
+            if !entry.url.isEmpty {
+                entries.append(entry)
+            }
+        }
+
+        guard !entries.isEmpty else { return nil }
+
+        return PlaylistInfo(
+            title: playlistTitle ?? "Playlist",
+            id: playlistId,
+            uploader: playlistUploader,
+            entries: entries,
+            url: url
+        )
+    }
+
     // MARK: - Download
 
     func download(

--- a/Fetch/Views/NewDownloadView.swift
+++ b/Fetch/Views/NewDownloadView.swift
@@ -21,6 +21,8 @@ struct NewDownloadView: View {
     @State private var batchMode = false
     @State private var batchURLs: [String] = []
     @State private var batchSelected: Set<String> = []
+    @State private var playlistInfo: PlaylistInfo?
+    @State private var showPlaylistPicker = false
 
     // Advanced options — args built by AdvancedOptionsView
     @State private var advancedArgs: [String] = []
@@ -36,6 +38,27 @@ struct NewDownloadView: View {
             .padding(24)
         }
         .navigationTitle("New Download")
+        .sheet(isPresented: $showPlaylistPicker) {
+            if let playlist = playlistInfo {
+                PlaylistPickerView(playlist: playlist, isPresented: $showPlaylistPicker) { entries in
+                    for entry in entries {
+                        manager.enqueue(
+                            url: entry.url,
+                            title: entry.title,
+                            formatId: nil,
+                            additionalArgs: advancedArgs,
+                            thumbnailURL: entry.thumbnailURL?.absoluteString,
+                            duration: entry.duration,
+                            playlistTitle: playlist.title,
+                            playlistIndex: entry.index,
+                            playlistId: playlist.id
+                        )
+                    }
+                    urlText = ""
+                    playlistInfo = nil
+                }
+            }
+        }
         .onChange(of: initialURL) { _, newValue in
             if let newValue, !newValue.isEmpty, newValue != urlText {
                 urlText = newValue
@@ -434,14 +457,23 @@ struct NewDownloadView: View {
         fetchTask?.cancel()
         error = nil
         mediaInfo = nil
+        playlistInfo = nil
         isLoading = true
 
         let url = urlText
         fetchTask = Task {
             do {
-                let info = try await manager.fetchMediaInfo(for: url)
-                guard !Task.isCancelled else { return }
-                mediaInfo = info
+                // Try playlist detection first
+                if let playlist = try await manager.fetchPlaylistInfo(for: url) {
+                    guard !Task.isCancelled else { return }
+                    playlistInfo = playlist
+                    showPlaylistPicker = true
+                } else {
+                    // Single video
+                    let info = try await manager.fetchMediaInfo(for: url)
+                    guard !Task.isCancelled else { return }
+                    mediaInfo = info
+                }
             } catch {
                 guard !Task.isCancelled else { return }
                 self.error = error.localizedDescription

--- a/Fetch/Views/PlaylistPickerView.swift
+++ b/Fetch/Views/PlaylistPickerView.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+
+/// Sheet for browsing and selecting playlist entries to download.
+struct PlaylistPickerView: View {
+    let playlist: PlaylistInfo
+    @Binding var isPresented: Bool
+    let onDownload: ([PlaylistEntry]) -> Void
+
+    @State private var selectedEntries: Set<String> = []
+    @State private var searchText = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            VStack(spacing: Design.Spacing.sm) {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(playlist.title)
+                            .font(.title3.weight(.semibold))
+                            .tracking(-0.3)
+                        if let uploader = playlist.uploader {
+                            Text(uploader)
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    Spacer()
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text("\(playlist.entries.count) items")
+                            .font(.callout.bold())
+                        if let total = playlist.totalDuration {
+                            Text("Total: \(DurationFormatter.format(total))")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                HStack {
+                    Button("Select All") {
+                        selectedEntries = Set(filteredEntries.map(\.id))
+                    }
+                    Button("Deselect All") {
+                        selectedEntries.removeAll()
+                    }
+                    Spacer()
+                    Text("\(selectedEntries.count) selected")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .font(.caption)
+            }
+            .padding()
+
+            Divider()
+
+            // Entry list
+            List {
+                ForEach(filteredEntries) { entry in
+                    HStack(spacing: Design.Spacing.md) {
+                        Toggle("", isOn: Binding(
+                            get: { selectedEntries.contains(entry.id) },
+                            set: { isOn in
+                                if isOn { selectedEntries.insert(entry.id) }
+                                else { selectedEntries.remove(entry.id) }
+                            }
+                        ))
+                        .toggleStyle(.checkbox)
+                        .labelsHidden()
+
+                        // Thumbnail
+                        if let thumbURL = entry.thumbnailURL {
+                            AsyncImage(url: thumbURL) { image in
+                                image.resizable().aspectRatio(contentMode: .fill)
+                            } placeholder: {
+                                RoundedRectangle(cornerRadius: 4).fill(.quaternary)
+                            }
+                            .frame(width: 48, height: 30)
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                            .accessibilityHidden(true)
+                        }
+
+                        // Info
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(entry.title)
+                                .font(.callout)
+                                .lineLimit(1)
+                            if let dur = entry.formattedDuration {
+                                Text(dur)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .monospacedDigit()
+                            }
+                        }
+
+                        Spacer()
+
+                        Text("#\(entry.index)")
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.tertiary)
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+            .listStyle(.inset(alternatesRowBackgrounds: true))
+            .searchable(text: $searchText, prompt: "Search entries...")
+
+            Divider()
+
+            // Footer
+            HStack {
+                Button("Cancel") {
+                    isPresented = false
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Spacer()
+
+                Button("Download \(selectedEntries.count) Items") {
+                    let selected = playlist.entries.filter { selectedEntries.contains($0.id) }
+                    onDownload(selected)
+                    isPresented = false
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(selectedEntries.isEmpty)
+                .keyboardShortcut(.defaultAction)
+            }
+            .padding()
+        }
+        .frame(minWidth: 600, minHeight: 500)
+        .onAppear {
+            // Select all by default
+            selectedEntries = Set(playlist.entries.map(\.id))
+        }
+    }
+
+    private var filteredEntries: [PlaylistEntry] {
+        guard !searchText.isEmpty else { return playlist.entries }
+        let query = searchText.lowercased()
+        return playlist.entries.filter { $0.title.lowercased().contains(query) }
+    }
+}


### PR DESCRIPTION
## Summary
- Auto-detect playlists from URL
- PlaylistPickerView: browse entries with thumbnails, select/deselect
- Playlist downloads organized in subfolders
- Download model carries playlist metadata for Library/History grouping

Partially addresses #10

## Test Plan
- [x] Build succeeds, 21/21 tests pass
- [ ] YouTube playlist URL → picker sheet shows all entries
- [ ] Selected entries download to playlist subfolder
- [ ] History shows playlist grouping metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)