### PR TITLE
feat: scheduled downloads — queue for later with timer

### DIFF
--- a/Fetch/Services/DownloadManager.swift
+++ b/Fetch/Services/DownloadManager.swift
@@ -79,7 +79,8 @@ final class DownloadManager {
         duration: Double? = nil,
         playlistTitle: String? = nil,
         playlistIndex: Int? = nil,
-        playlistId: String? = nil
+        playlistId: String? = nil,
+        scheduledFor: Date? = nil
     ) {
         var combinedArgs = preset?.asArguments() ?? []
         combinedArgs += additionalArgs
@@ -106,11 +107,26 @@ final class DownloadManager {
             duration: duration,
             playlistTitle: playlistTitle,
             playlistIndex: playlistIndex,
-            playlistId: playlistId
+            playlistId: playlistId,
+            scheduledFor: scheduledFor
         )
 
-        activeTasks.append(task)
-        processQueue()
+        if let scheduledFor {
+            // Scheduled download — set to scheduled status, start timer
+            task.status = .scheduled
+            activeTasks.append(task)
+            let delay = max(scheduledFor.timeIntervalSinceNow, 0)
+            Task { @MainActor in
+                try? await Task.sleep(for: .seconds(delay))
+                guard task.status == .scheduled else { return }
+                task.status = .queued
+                processQueue()
+                updateDockBadge()
+            }
+        } else {
+            activeTasks.append(task)
+            processQueue()
+        }
         updateDockBadge()
     }
 
@@ -298,6 +314,7 @@ final class DownloadTask: Identifiable, @unchecked Sendable {
     let playlistTitle: String?
     let playlistIndex: Int?
     let playlistId: String?
+    let scheduledFor: Date?
     let dateCreated = Date()
 
     var title: String?
@@ -323,7 +340,8 @@ final class DownloadTask: Identifiable, @unchecked Sendable {
         duration: Double? = nil,
         playlistTitle: String? = nil,
         playlistIndex: Int? = nil,
-        playlistId: String? = nil
+        playlistId: String? = nil,
+        scheduledFor: Date? = nil
     ) {
         self.url = url
         self.title = title
@@ -338,13 +356,15 @@ final class DownloadTask: Identifiable, @unchecked Sendable {
         self.playlistTitle = playlistTitle
         self.playlistIndex = playlistIndex
         self.playlistId = playlistId
+        self.scheduledFor = scheduledFor
     }
 
     enum DownloadTaskStatus: String {
-        case queued, downloading, postprocessing, completed, failed, cancelled
+        case scheduled, queued, downloading, postprocessing, completed, failed, cancelled
 
         var label: String {
             switch self {
+            case .scheduled: "Scheduled"
             case .queued: "Queued"
             case .downloading: "Downloading"
             case .postprocessing: "Processing"
@@ -356,6 +376,7 @@ final class DownloadTask: Identifiable, @unchecked Sendable {
 
         var icon: String {
             switch self {
+            case .scheduled: "calendar.badge.clock"
             case .queued: "clock"
             case .downloading: "arrow.down.circle"
             case .postprocessing: "gearshape.2"

--- a/Fetch/Views/DownloadRowView.swift
+++ b/Fetch/Views/DownloadRowView.swift
@@ -41,6 +41,18 @@ struct DownloadRowView: View {
                     .lineLimit(1)
                     .tracking(-0.2)
 
+                // Scheduled time
+                if task.status == .scheduled, let scheduledFor = task.scheduledFor {
+                    HStack(spacing: 4) {
+                        Image(systemName: "calendar.badge.clock")
+                            .font(.caption)
+                            .foregroundStyle(.purple)
+                        Text("Scheduled for \(scheduledFor, style: .relative)")
+                            .font(.caption)
+                            .foregroundStyle(.purple)
+                    }
+                }
+
                 // Progress bar
                 if task.status == .downloading || task.status == .postprocessing {
                     ProgressView(value: task.progress, total: 100)
@@ -138,6 +150,7 @@ struct DownloadRowView: View {
 
     private var statusColor: Color {
         switch task.status {
+        case .scheduled: .purple
         case .queued: .secondary
         case .downloading: Color.accentColor
         case .postprocessing: .orange


### PR DESCRIPTION
## Summary
- Schedule downloads for a future time
- .scheduled status with purple badge and countdown
- Task.sleep timer transitions to .queued at the right time

Closes #40

## Test Plan
- [x] Build + 21/21 tests
- [ ] Scheduled task shows countdown in queue
- [ ] Task starts downloading at scheduled time
- [ ] Cancel prevents scheduled task from starting

🤖 Generated with [Claude Code](https://claude.com/claude-code)