### PR TITLE
feat: AI-optimized export presets — Whisper, transcript, vision, FLAC

### DIFF
--- a/Fetch/Models/Preset.swift
+++ b/Fetch/Models/Preset.swift
@@ -76,4 +76,19 @@ final class Preset {
             Preset(name: "Podcast", formatSelection: "bestaudio", preferredQuality: "audio", extraArguments: "--extract-audio --audio-format mp3 --audio-quality 5 --embed-thumbnail --embed-metadata"),
         ]
     }
+
+    static var aiBuiltIn: [Preset] {
+        [
+            Preset(name: "AI: Speech-to-Text (Whisper)", formatSelection: "bestaudio", preferredQuality: "audio",
+                   extraArguments: "--extract-audio --audio-format wav --postprocessor-args \"ffmpeg:-ar 16000 -ac 1\""),
+            Preset(name: "AI: Transcript Only", formatSelection: "bestaudio", preferredQuality: "audio",
+                   extraArguments: "--write-auto-subs --sub-format vtt --skip-download --sub-langs en.*,en"),
+            Preset(name: "AI: Audio + Transcript", formatSelection: "bestaudio", preferredQuality: "audio",
+                   extraArguments: "--extract-audio --audio-format mp3 --audio-quality 0 --write-auto-subs --sub-format vtt --sub-langs en.*,en"),
+            Preset(name: "AI: Vision Frames (1fps)", formatSelection: "bestvideo[height<=1080]", preferredQuality: "1080p",
+                   extraArguments: "--postprocessor-args \"ffmpeg:-vf fps=1\" --write-thumbnail"),
+            Preset(name: "AI: Music Lossless (FLAC)", formatSelection: "bestaudio", preferredQuality: "audio",
+                   extraArguments: "--extract-audio --audio-format flac"),
+        ]
+    }
 }

--- a/Fetch/Views/PresetEditorView.swift
+++ b/Fetch/Views/PresetEditorView.swift
@@ -19,6 +19,13 @@ struct PresetEditorView: View {
                     }
                 }
 
+                Section("AI & Research") {
+                    ForEach(Preset.aiBuiltIn, id: \.name) { preset in
+                        Label(preset.name, systemImage: "cpu")
+                            .tag(preset)
+                    }
+                }
+
                 if !presets.isEmpty {
                     Section("Custom") {
                         ForEach(presets) { preset in


### PR DESCRIPTION
## Summary
- 5 AI-focused built-in presets: Whisper, Transcript Only, Audio+Transcript, Vision Frames, Music Lossless
- PresetEditorView: split into "Built-in" and "AI & Research" sections

Closes #14
🤖 Generated with [Claude Code](https://claude.com/claude-code)