### PR TITLE
a11y: fix .tertiary contrast on URL text

### DIFF
--- a/Fetch/Views/DownloadRowView.swift
+++ b/Fetch/Views/DownloadRowView.swift
@@ -105,7 +105,7 @@ struct DownloadRowView: View {
                     Spacer()
                     Text(task.url)
                         .font(.caption)
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(.secondary)
                         .lineLimit(1)
                         .truncationMode(.middle)
                         .frame(maxWidth: 200)


### PR DESCRIPTION
Closes #89. .tertiary→.secondary (2.88:1→4.74:1).