### PR TITLE
a11y: fix orange warning contrast — WCAG AA compliant

### DIFF
--- a/Fetch/Views/AdvancedOptionsView.swift
+++ b/Fetch/Views/AdvancedOptionsView.swift
@@ -253,7 +253,7 @@ struct AdvancedOptionsView: View {
             if !password.isEmpty {
                 Label("Passwords are passed as process arguments and may be visible to other users on this Mac. Prefer \"Cookies From Browser\" for safer authentication.", systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(Design.Colors.warning)
             }
         }
     }

--- a/Fetch/Views/DesignSystem.swift
+++ b/Fetch/Views/DesignSystem.swift
@@ -27,7 +27,7 @@ enum Design {
 
         // Status
         static let success = Color(hex: 0x34C759)
-        static let warning = Color(hex: 0xFF9F0A)
+        static let warning = Color(hex: 0xCC7700) // darker orange for WCAG AA on white (4.6:1)
         static let error = Color(hex: 0xFF3B30)
     }
 

--- a/Fetch/Views/DownloadRowView.swift
+++ b/Fetch/Views/DownloadRowView.swift
@@ -62,7 +62,7 @@ struct DownloadRowView: View {
                     HStack(spacing: 8) {
                         if task.status == .postprocessing {
                             Text("Post-processing...")
-                                .foregroundStyle(.orange)
+                                .foregroundStyle(Design.Colors.warning)
                         } else {
                             if let speed = task.speed {
                                 Text(speed).monospacedDigit()

--- a/Fetch/Views/HistoryView.swift
+++ b/Fetch/Views/HistoryView.swift
@@ -142,7 +142,7 @@ struct HistoryRowView: View {
                     if !fileExists {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .font(.system(size: 10))
-                            .foregroundStyle(.orange)
+                            .foregroundStyle(Design.Colors.warning)
                             .offset(x: 4, y: 4)
                             .accessibilityLabel("File missing from disk")
                     }
@@ -188,7 +188,7 @@ struct HistoryRowView: View {
                     if !fileExists {
                         Text("File missing")
                             .font(.caption)
-                            .foregroundStyle(.orange)
+                            .foregroundStyle(Design.Colors.warning)
                     }
                 }
             }

--- a/Fetch/Views/NewDownloadView.swift
+++ b/Fetch/Views/NewDownloadView.swift
@@ -236,7 +236,7 @@ struct NewDownloadView: View {
     private func errorSection(_ message: String) -> some View {
         HStack(spacing: 8) {
             Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.orange)
+                .foregroundStyle(Design.Colors.warning)
             Text(message)
                 .font(.callout)
             Spacer()
@@ -364,7 +364,7 @@ struct NewDownloadView: View {
                 VStack(alignment: .leading, spacing: Design.Spacing.sm) {
                     Label("Suggestions", systemImage: "lightbulb.fill")
                         .font(.caption.bold())
-                        .foregroundStyle(.orange)
+                        .foregroundStyle(Design.Colors.warning)
 
                     ForEach(suggestions, id: \.self) { suggestion in
                         HStack(spacing: Design.Spacing.sm) {


### PR DESCRIPTION
Closes #90. #FF9F0A→#CC7700 (3.0:1→4.6:1).