### PR TITLE
security: validate URL scheme before passing to yt-dlp

### DIFF
--- a/Fetch/Views/NewDownloadView.swift
+++ b/Fetch/Views/NewDownloadView.swift
@@ -496,9 +496,21 @@ struct NewDownloadView: View {
         error = nil
         mediaInfo = nil
         playlistInfo = nil
+        contentInsights = []
         isLoading = true
 
-        let url = urlText
+        let url = urlText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Defense-in-depth: only allow http/https URLs
+        guard let parsed = URL(string: url),
+              let scheme = parsed.scheme,
+              ["http", "https"].contains(scheme.lowercased()),
+              parsed.host != nil
+        else {
+            error = "Invalid URL. Only http:// and https:// URLs are supported."
+            isLoading = false
+            return
+        }
         fetchTask = Task {
             do {
                 // Try playlist detection first


### PR DESCRIPTION
Closes #93. Block non-http schemes.