### PR TITLE
docs: fix broken screenshots + sync architecture trees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,25 +30,41 @@ xcodebuild -project Fetch.xcodeproj -scheme Fetch -destination 'platform=macOS' 
 
 ```
 Fetch/
-├── FetchApp.swift              @main entry, WindowGroup + MenuBarExtra + Settings
+├── FetchApp.swift                  @main entry, WindowGroup + MenuBarExtra + Settings
 ├── Models/
-│   ├── Download.swift          SwiftData @Model — persisted download history
-│   ├── Preset.swift            SwiftData @Model — saved download presets
-│   └── FormatOption.swift      Value types: FormatOption + MediaInfo (parsed from yt-dlp JSON)
+│   ├── Download.swift              SwiftData @Model — persisted download history
+│   ├── Preset.swift                SwiftData @Model — saved download presets
+│   └── FormatOption.swift          Value types: FormatOption, MediaInfo, PlaylistInfo
 ├── Services/
-│   ├── YTDLPService.swift      actor — all yt-dlp process execution goes through here
-│   ├── DownloadManager.swift   @Observable @MainActor — download queue, drives UI
-│   └── ClipboardMonitor.swift  @Observable @MainActor — NSPasteboard URL detection
+│   ├── YTDLPService.swift          Actor — all yt-dlp process execution
+│   ├── FfmpegService.swift         Actor — ffprobe analysis + ffmpeg processing
+│   ├── DownloadManager.swift       @Observable @MainActor — download queue, drives UI
+│   ├── ClipboardMonitor.swift      @Observable @MainActor — NSPasteboard URL detection
+│   ├── NotificationService.swift   UNUserNotificationCenter + Dock badge
+│   ├── SpotlightService.swift      CoreSpotlight indexing of downloads
+│   ├── URLParser.swift             Multi-format URL extraction + validation
+│   ├── TextAnalysisService.swift   NaturalLanguage — keywords, sentiment, insights
+│   └── AppIntentsProvider.swift    Siri Shortcuts integration
 └── Views/
-    ├── ContentView.swift       Root NavigationSplitView + ClipboardBanner + SidebarSection enum
-    ├── SidebarView.swift       Sidebar nav + yt-dlp version footer
-    ├── NewDownloadView.swift   URL input → fetch info → format picker → download button
-    ├── DownloadQueueView.swift Active download list + context menus
-    ├── DownloadRowView.swift   Single download row with progress bar
-    ├── FormatPickerView.swift  Full format table (sheet) with filters
-    ├── HistoryView.swift       SwiftData query of past downloads
-    ├── PresetEditorView.swift  Preset list + detail editor (HSplitView)
-    └── SettingsView.swift      App settings (TabView: General, Downloads, Advanced)
+    ├── ContentView.swift           Root NavigationSplitView + ClipboardBanner + SidebarSection enum
+    ├── SidebarView.swift           Sidebar nav + yt-dlp version footer
+    ├── NewDownloadView.swift       URL input → fetch info → format picker → download
+    ├── DownloadQueueView.swift     Active download list + context menus
+    ├── DownloadRowView.swift       Single download row with progress bar
+    ├── FormatPickerView.swift      Full format table (sheet) with filters
+    ├── PlaylistPickerView.swift    Playlist entry picker with 5 download modes
+    ├── TranscriptOptionsView.swift Subtitle language/format picker
+    ├── AdvancedOptionsView.swift   Post-processing, network, auth, output options
+    ├── HistoryView.swift           SwiftData query of past downloads
+    ├── LibraryView.swift           Catalog with sort/filter/search, list+grid views
+    ├── StatsView.swift             Swift Charts — extractor, format, timeline
+    ├── FfmpegLabView.swift         8-panel post-processing lab
+    ├── PresetEditorView.swift      Preset list + detail editor (HSplitView)
+    ├── SettingsView.swift          App settings (TabView: General, Downloads, Advanced)
+    ├── OnboardingView.swift        4-step interactive walkthrough
+    ├── DesignSystem.swift          Apple design tokens — colors, spacing, elevation
+    ├── AuroraView.swift            Animated gradients + shimmer + pulsing glow
+    └── TipBanner.swift             Rotating contextual tips for empty states
 ```
 
 ## Key Patterns — READ BEFORE CODING

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Fetch wraps yt-dlp with a polished native interface — paste a URL, pick a form
 
 ## Screenshots
 
-| Media Info + Transcripts | FFmpeg Lab | Playlist Picker |
+| Media Info + Transcripts | FFmpeg Lab | History |
 |:---:|:---:|:---:|
-| ![Media Info](screenshots/media-info-view.png) | ![FFmpeg Lab](screenshots/ffmpeg-lab-view.png) | ![Playlist](screenshots/playlist-picker-view.png) |
+| ![Media Info](screenshots/media-info-view.png) | ![FFmpeg Lab](screenshots/ffmpeg-lab-view.png) | ![History](screenshots/history-view.png) |
 
 | Library | Stats | Presets (11 built-in) |
 |:---:|:---:|:---:|
@@ -79,27 +79,41 @@ Or open `Fetch.xcodeproj` in Xcode 16+ and build (Cmd+B).
 
 ```text
 Fetch/
-├── FetchApp.swift              @main entry — WindowGroup, MenuBarExtra, Settings
+├── FetchApp.swift                  @main entry — WindowGroup, MenuBarExtra, Settings
 ├── Models/
-│   ├── Download.swift          SwiftData @Model — persisted download history
-│   ├── Preset.swift            SwiftData @Model — saved download presets
-│   └── FormatOption.swift      Value types: FormatOption + MediaInfo
+│   ├── Download.swift              SwiftData @Model — persisted download history
+│   ├── Preset.swift                SwiftData @Model — saved download presets
+│   └── FormatOption.swift          Value types: FormatOption, MediaInfo, PlaylistInfo
 ├── Services/
-│   ├── YTDLPService.swift      Actor — all yt-dlp process execution
-│   ├── DownloadManager.swift   @Observable @MainActor — download queue
-│   ├── ClipboardMonitor.swift  @Observable @MainActor — pasteboard URL detection
-│   └── NotificationService.swift  UNUserNotificationCenter + Dock badge
+│   ├── YTDLPService.swift          Actor — all yt-dlp process execution
+│   ├── FfmpegService.swift         Actor — ffprobe analysis + ffmpeg processing
+│   ├── DownloadManager.swift       @Observable @MainActor — download queue
+│   ├── ClipboardMonitor.swift      @Observable @MainActor — pasteboard URL detection
+│   ├── NotificationService.swift   UNUserNotificationCenter + Dock badge
+│   ├── SpotlightService.swift      CoreSpotlight indexing of downloads
+│   ├── URLParser.swift             Multi-format URL extraction + validation
+│   ├── TextAnalysisService.swift   NaturalLanguage — keywords, sentiment, insights
+│   └── AppIntentsProvider.swift    Siri Shortcuts integration
 └── Views/
-    ├── ContentView.swift       Root NavigationSplitView + clipboard banner
-    ├── SidebarView.swift       Sidebar navigation + yt-dlp version footer
-    ├── NewDownloadView.swift   URL input → fetch info → format picker → download
-    ├── DownloadQueueView.swift Active downloads + context menus
-    ├── DownloadRowView.swift   Single download row with shimmer progress
-    ├── FormatPickerView.swift  Full format table (sheet) with filters
-    ├── HistoryView.swift       SwiftData query of past downloads
-    ├── PresetEditorView.swift  Preset list + detail editor
-    ├── SettingsView.swift      App settings (General, Downloads, Advanced)
-    └── AuroraView.swift        Animated gradient background + shimmer style
+    ├── ContentView.swift           Root NavigationSplitView + clipboard banner
+    ├── SidebarView.swift           Sidebar navigation + yt-dlp version footer
+    ├── NewDownloadView.swift       URL input → fetch info → format picker → download
+    ├── DownloadQueueView.swift     Active downloads + context menus
+    ├── DownloadRowView.swift       Single download row with shimmer progress
+    ├── FormatPickerView.swift      Full format table (sheet) with filters
+    ├── PlaylistPickerView.swift    Playlist entry picker with 5 download modes
+    ├── TranscriptOptionsView.swift Subtitle language/format picker
+    ├── AdvancedOptionsView.swift   Post-processing, network, auth, output options
+    ├── HistoryView.swift           SwiftData query of past downloads
+    ├── LibraryView.swift           Catalog with sort/filter/search, list+grid views
+    ├── StatsView.swift             Swift Charts — extractor, format, timeline
+    ├── FfmpegLabView.swift         8-panel post-processing lab
+    ├── PresetEditorView.swift      Preset list + detail editor (HSplitView)
+    ├── SettingsView.swift          App settings (General, Downloads, Advanced)
+    ├── OnboardingView.swift        4-step interactive walkthrough
+    ├── DesignSystem.swift          Apple design tokens — colors, spacing, elevation
+    ├── AuroraView.swift            Animated gradients + shimmer + pulsing glow
+    └── TipBanner.swift             Rotating contextual tips for empty states
 ```
 
 ### Key Design Decisions

--- a/docs/index.html
+++ b/docs/index.html
@@ -1020,10 +1020,10 @@
             </div>
         </div>
         <div class="showcase-card featured reveal reveal-delay-4">
-            <img src="https://raw.githubusercontent.com/twitchyvr/Fetch/main/screenshots/playlist-picker-view.png" alt="Playlist Picker for batch selection" loading="lazy">
+            <img src="https://raw.githubusercontent.com/twitchyvr/Fetch/main/screenshots/presets-view.png" alt="Presets with 11 built-in configurations" loading="lazy">
             <div class="showcase-card-info">
-                <h3>Playlist Picker</h3>
-                <p>Cherry-pick individual videos from playlists or download entire channels in one click.</p>
+                <h3>Presets</h3>
+                <p>6 built-in + 5 AI research presets. One-click for Whisper, transcript, lossless, and more.</p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Fixed broken `playlist-picker-view.png` references in README.md and docs/index.html (file never existed — both rendered broken images on GitHub and the landing page)
- Updated architecture trees in README.md, CLAUDE.md, and Wiki to reflect current source: 9 services, 19 views, 3 models (was showing 4 services and 10 views)

## Test plan
- [x] `xcodebuild build` — passes
- [x] `xcodebuild test` — 36/36 pass
- [x] All 6 screenshot references in README now point to files that exist in `screenshots/`
- [x] All 5 screenshot references in `docs/index.html` now point to valid files
- [x] Architecture file lists match `ls Fetch/{Models,Services,Views}/*.swift`

Closes documentation drift found during full verification loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)