### PR TITLE
security: sanitize error messages — no internal-detail leaks

### DIFF
--- a/Fetch/Services/FfmpegService.swift
+++ b/Fetch/Services/FfmpegService.swift
@@ -56,7 +56,7 @@ actor FfmpegService {
         guard let data = output.data(using: .utf8),
               let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         else {
-            throw FfmpegError.parseError("Failed to parse ffprobe output")
+            throw FfmpegError.parseError(detail: "Failed to parse ffprobe output")
         }
 
         return MediaProbe(json: json, filePath: filePath)
@@ -118,7 +118,7 @@ actor FfmpegService {
                     let errStr = String(data: outputBuffer.get(), encoding: .utf8) ?? ""
                     continuation.resume(throwing: FfmpegError.processError(
                         code: proc.terminationStatus,
-                        message: errStr
+                        rawDetail: errStr
                     ))
                 }
             }
@@ -168,7 +168,7 @@ actor FfmpegService {
                     continuation.resume(returning: outStr)
                 } else {
                     continuation.resume(throwing: FfmpegError.processError(
-                        code: proc.terminationStatus, message: outStr
+                        code: proc.terminationStatus, rawDetail: outStr
                     ))
                 }
             }
@@ -252,17 +252,62 @@ struct MediaProbe: Sendable {
 
 enum FfmpegError: LocalizedError {
     case binaryNotFound
-    case processError(code: Int32, message: String)
-    case parseError(String)
+    /// `rawDetail` is captured for internal logging only — NEVER surfaced to the UI.
+    /// `errorDescription` returns a sanitized message that drops absolute paths,
+    /// ffmpeg internal command details, and raw stderr.
+    case processError(code: Int32, rawDetail: String)
+    case parseError(detail: String)
 
     var errorDescription: String? {
         switch self {
         case .binaryNotFound:
-            "FFmpeg not found. Install via Homebrew: brew install ffmpeg"
-        case .processError(let code, let message):
-            "FFmpeg error (code \(code)): \(message)"
-        case .parseError(let detail):
-            "Failed to parse FFmpeg output: \(detail)"
+            return "FFmpeg not found. Install it via Homebrew: brew install ffmpeg"
+        case .processError(_, let rawDetail):
+            return Self.sanitize(stderr: rawDetail)
+        case .parseError:
+            return "Couldn't read information about this file."
         }
+    }
+
+    /// Internal-only: the raw stderr from ffmpeg. Use only for developer logging.
+    var internalDetail: String? {
+        switch self {
+        case .binaryNotFound: return nil
+        case .processError(let code, let rawDetail): return "code \(code): \(rawDetail)"
+        case .parseError(let detail): return detail
+        }
+    }
+
+    /// Maps known ffmpeg stderr patterns to user-safe messages. Drops file paths,
+    /// command-line details, and any raw stderr.
+    static func sanitize(stderr: String) -> String {
+        let lower = stderr.lowercased()
+
+        if lower.contains("no such file or directory") {
+            return "The input file couldn't be found. It may have been moved or deleted."
+        }
+        if lower.contains("permission denied") {
+            return "Permission denied accessing the file."
+        }
+        if lower.contains("invalid data found") || lower.contains("moov atom not found") {
+            return "The input file is corrupt or not a supported media format."
+        }
+        if lower.contains("encoder not found") || lower.contains("unknown encoder") {
+            return "The selected codec isn't available in your FFmpeg build."
+        }
+        if lower.contains("decoder not found") || lower.contains("unknown decoder") {
+            return "The input file uses a codec your FFmpeg build can't decode."
+        }
+        if lower.contains("no space left on device") {
+            return "Out of disk space. Free up some space and try again."
+        }
+        if lower.contains("conversion failed") || lower.contains("error initializing filter") {
+            return "FFmpeg couldn't process the file with these settings. Try different options."
+        }
+        if lower.contains("output file") && lower.contains("already exists") {
+            return "An output file with that name already exists."
+        }
+
+        return "FFmpeg couldn't process this file. Try different settings or check the input."
     }
 }

--- a/Fetch/Services/YTDLPService.swift
+++ b/Fetch/Services/YTDLPService.swift
@@ -52,7 +52,7 @@ actor YTDLPService {
         guard let data = result.output.data(using: .utf8),
               let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         else {
-            throw YTDLPError.parseError("Failed to parse media info JSON")
+            throw YTDLPError.parseError(detail: "Failed to parse media info JSON")
         }
 
         return MediaInfo(json: json, url: url)
@@ -338,7 +338,7 @@ actor YTDLPService {
                 if proc.terminationStatus != 0 {
                     continuation.resume(throwing: YTDLPError.processError(
                         code: proc.terminationStatus,
-                        message: errStr.isEmpty ? outStr : errStr
+                        rawDetail: errStr.isEmpty ? outStr : errStr
                     ))
                 } else {
                     continuation.resume(returning: ShellResult(
@@ -401,7 +401,7 @@ actor YTDLPService {
                 } else {
                     continuation.resume(throwing: YTDLPError.processError(
                         code: proc.terminationStatus,
-                        message: "yt-dlp exited with code \(proc.terminationStatus)"
+                        rawDetail: "yt-dlp exited with code \(proc.terminationStatus)"
                     ))
                 }
             }
@@ -446,18 +446,107 @@ struct CLIOption: Identifiable, Sendable {
 
 enum YTDLPError: LocalizedError {
     case binaryNotFound
-    case processError(code: Int32, message: String)
-    case parseError(String)
+    /// `rawDetail` is captured for internal logging only — NEVER surfaced to the UI.
+    /// `errorDescription` returns a sanitized message that drops paths, hostnames,
+    /// tracebacks, and any other internal details from yt-dlp stderr.
+    case processError(code: Int32, rawDetail: String)
+    case parseError(detail: String)
 
     var errorDescription: String? {
         switch self {
         case .binaryNotFound:
-            "yt-dlp not found. Install via Homebrew: brew install yt-dlp"
-        case .processError(let code, let message):
-            "yt-dlp error (code \(code)): \(message)"
-        case .parseError(let detail):
-            "Failed to parse yt-dlp output: \(detail)"
+            return "yt-dlp not found. Install it via Homebrew: brew install yt-dlp"
+        case .processError(_, let rawDetail):
+            return Self.sanitize(stderr: rawDetail)
+        case .parseError:
+            return "Couldn't read information about this video. Try a different URL."
         }
+    }
+
+    /// Internal-only: the raw stderr captured from the yt-dlp process. Use only for
+    /// developer logging, never for UI display.
+    var internalDetail: String? {
+        switch self {
+        case .binaryNotFound: return nil
+        case .processError(let code, let rawDetail): return "code \(code): \(rawDetail)"
+        case .parseError(let detail): return detail
+        }
+    }
+
+    /// Maps known yt-dlp stderr patterns to user-safe messages. The raw stderr is
+    /// NEVER returned — unmatched errors fall through to a generic message. This is
+    /// a defense against leaking absolute paths, hostnames, cookie locations, auth
+    /// tokens in URLs, Python tracebacks, and internal yt-dlp module identifiers.
+    static func sanitize(stderr: String) -> String {
+        let lower = stderr.lowercased()
+
+        // --- Network failures ---
+        if lower.contains("nodename nor servname")
+            || lower.contains("could not resolve")
+            || lower.contains("temporary failure in name resolution")
+            || lower.contains("name or service not known") {
+            return "Couldn't reach the server. Check your internet connection."
+        }
+        if lower.contains("connection refused")
+            || lower.contains("connection timed out")
+            || lower.contains("network is unreachable") {
+            return "The server isn't responding. Try again in a moment."
+        }
+        if lower.contains("ssl") && (lower.contains("certificate") || lower.contains("handshake")) {
+            return "Couldn't establish a secure connection to the server."
+        }
+
+        // --- HTTP statuses ---
+        if lower.contains("http error 403") || lower.contains("forbidden") {
+            return "Access was refused. The video may be region-locked or require sign-in."
+        }
+        if lower.contains("http error 404") {
+            return "Video not found. It may have been removed."
+        }
+        if lower.contains("http error 429") || lower.contains("too many requests") {
+            return "Rate-limited by the server. Wait a moment and try again."
+        }
+        if lower.contains("http error 5") {
+            return "The server returned an error. Try again later."
+        }
+
+        // --- Common yt-dlp messages ---
+        if lower.contains("video unavailable") || lower.contains("video has been removed") {
+            return "This video is no longer available."
+        }
+        if lower.contains("private video") || lower.contains("members-only")
+            || lower.contains("members only") {
+            return "This video is private or members-only."
+        }
+        if lower.contains("age") && (lower.contains("restricted") || lower.contains("confirm")) {
+            return "This video is age-restricted. Sign-in cookies may be required."
+        }
+        if lower.contains("sign in") || lower.contains("login required")
+            || lower.contains("requires authentication") {
+            return "This video requires sign-in. Add a cookies file in Advanced Options."
+        }
+        if lower.contains("not available in your country")
+            || lower.contains("not available in your location")
+            || lower.contains("geo") && lower.contains("block") {
+            return "This video isn't available in your region."
+        }
+        if lower.contains("unsupported url") {
+            return "Fetch doesn't recognize this URL. Make sure it points to a video page."
+        }
+        if lower.contains("live event will begin")
+            || lower.contains("premiere will begin")
+            || lower.contains("upcoming") {
+            return "This live stream or premiere hasn't started yet."
+        }
+        if lower.contains("copyright") {
+            return "This video is unavailable due to copyright restrictions."
+        }
+        if lower.contains("postprocessing") || lower.contains("ffmpeg") {
+            return "Couldn't post-process the downloaded file. Make sure FFmpeg is installed."
+        }
+
+        // --- Default: never echo raw stderr ---
+        return "yt-dlp couldn't process this video. Try a different URL or update yt-dlp."
     }
 }
 

--- a/Fetch/Views/LibraryView.swift
+++ b/Fetch/Views/LibraryView.swift
@@ -328,7 +328,8 @@ struct LibraryView: View {
             let data = try JSONSerialization.data(withJSONObject: records, options: [.prettyPrinted, .sortedKeys])
             try data.write(to: url)
         } catch {
-            NSLog("Failed to export JSON: \(error.localizedDescription)")
+            // Internal-only log, no UI surface; do not include error.localizedDescription which can leak file paths
+            NSLog("Library: JSON export failed")
         }
     }
 
@@ -358,7 +359,8 @@ struct LibraryView: View {
         do {
             try csv.write(to: url, atomically: true, encoding: .utf8)
         } catch {
-            NSLog("Failed to export CSV: \(error.localizedDescription)")
+            // Internal-only log, no UI surface; do not include error.localizedDescription which can leak file paths
+            NSLog("Library: CSV export failed")
         }
     }
 

--- a/FetchTests/FetchTests.swift
+++ b/FetchTests/FetchTests.swift
@@ -385,4 +385,110 @@ struct SecurityTests {
         let urls = URLParser.extractURLs(from: "file:///etc/passwd\njavascript:alert(1)\ndata:text/html,<h1>hi</h1>")
         #expect(urls.isEmpty)
     }
+
+    // MARK: - Error message sanitization (must never leak internal details)
+
+    @Test("YTDLPError sanitizer does not leak absolute file paths")
+    func sanitizerDropsPaths() {
+        let stderr = "ERROR: Cookies file /Users/mattrogers/Library/Cookies/secret.txt could not be loaded"
+        let safe = YTDLPError.sanitize(stderr: stderr)
+        #expect(!safe.contains("/Users/mattrogers"))
+        #expect(!safe.contains("secret.txt"))
+        #expect(!safe.contains("/Library/Cookies"))
+    }
+
+    @Test("YTDLPError sanitizer does not leak hostnames or HTTP details")
+    func sanitizerDropsHostnames() {
+        let stderr = "ERROR: [generic] Unable to download webpage: HTTPSConnection(host='private-server.internal.example.com', port=443): Failed to resolve"
+        let safe = YTDLPError.sanitize(stderr: stderr)
+        #expect(!safe.contains("private-server.internal.example.com"))
+        #expect(!safe.contains("HTTPSConnection"))
+        #expect(!safe.contains("[generic]"))
+    }
+
+    @Test("YTDLPError sanitizer does not leak Python tracebacks")
+    func sanitizerDropsTracebacks() {
+        let stderr = """
+        Traceback (most recent call last):
+          File "/opt/homebrew/lib/python3.12/site-packages/yt_dlp/extractor/youtube.py", line 1234, in _extract
+            raise ExtractorError("internal: foo")
+        ExtractorError: internal: foo
+        """
+        let safe = YTDLPError.sanitize(stderr: stderr)
+        #expect(!safe.contains("Traceback"))
+        #expect(!safe.contains("/opt/homebrew"))
+        #expect(!safe.contains("python3.12"))
+        #expect(!safe.contains("ExtractorError"))
+    }
+
+    @Test("YTDLPError sanitizer maps DNS failure to friendly message")
+    func sanitizerNetworkError() {
+        let stderr = "ERROR: Unable to download webpage: <urlopen error [Errno 8] nodename nor servname provided>"
+        let safe = YTDLPError.sanitize(stderr: stderr)
+        #expect(safe.contains("internet connection"))
+        #expect(!safe.contains("urlopen"))
+        #expect(!safe.contains("Errno"))
+    }
+
+    @Test("YTDLPError sanitizer maps HTTP 403 to access-refused message")
+    func sanitizerForbidden() {
+        let stderr = "ERROR: unable to download video data: HTTP Error 403: Forbidden"
+        let safe = YTDLPError.sanitize(stderr: stderr)
+        #expect(safe.contains("refused") || safe.contains("region-locked"))
+        #expect(!safe.contains("HTTP Error 403"))
+    }
+
+    @Test("YTDLPError sanitizer maps unsupported URL to friendly message")
+    func sanitizerUnsupportedURL() {
+        let stderr = "ERROR: Unsupported URL: https://example.com/auth?token=abc123secret"
+        let safe = YTDLPError.sanitize(stderr: stderr)
+        #expect(!safe.contains("token=abc123secret"))
+        #expect(!safe.contains("example.com"))
+        #expect(safe.contains("recognize") || safe.contains("video page"))
+    }
+
+    @Test("YTDLPError sanitizer falls back to generic message for unknown stderr")
+    func sanitizerUnknownFallback() {
+        // Random gibberish that matches no known pattern — must NOT echo through
+        let stderr = "ERROR: weird internal yt-dlp message with /Users/secret/path and 192.168.1.5 and api_key=ABC"
+        let safe = YTDLPError.sanitize(stderr: stderr)
+        #expect(!safe.contains("/Users/secret/path"))
+        #expect(!safe.contains("192.168.1.5"))
+        #expect(!safe.contains("api_key=ABC"))
+        #expect(!safe.contains("weird internal"))
+    }
+
+    @Test("YTDLPError errorDescription returns sanitized text, not raw")
+    func errorDescriptionUsesSanitizer() {
+        let err = YTDLPError.processError(code: 1, rawDetail: "ERROR: HTTPSConnection(host='leaky.example.com'): Failed to resolve")
+        let description = err.errorDescription ?? ""
+        #expect(!description.contains("leaky.example.com"))
+        #expect(!description.contains("HTTPSConnection"))
+    }
+
+    @Test("YTDLPError internalDetail preserves raw stderr for logging")
+    func internalDetailPreservesRaw() {
+        let raw = "ERROR: HTTPSConnection(host='private.example.com'): Failed to resolve"
+        let err = YTDLPError.processError(code: 1, rawDetail: raw)
+        // internalDetail is meant for developer logs only, so it CAN include the raw text
+        #expect(err.internalDetail?.contains(raw) == true)
+    }
+
+    @Test("FfmpegError sanitizer does not leak absolute file paths")
+    func ffmpegSanitizerDropsPaths() {
+        let stderr = "/Users/mattrogers/Movies/private.mkv: No such file or directory"
+        let safe = FfmpegError.sanitize(stderr: stderr)
+        #expect(!safe.contains("/Users/mattrogers"))
+        #expect(!safe.contains("private.mkv"))
+        #expect(safe.contains("couldn't be found") || safe.contains("not be found"))
+    }
+
+    @Test("FfmpegError sanitizer maps invalid data to corrupt-file message")
+    func ffmpegSanitizerCorrupt() {
+        let stderr = "[mov,mp4,m4a,3gp,3g2,mj2 @ 0x148e042e0] moov atom not found\nInvalid data found when processing input"
+        let safe = FfmpegError.sanitize(stderr: stderr)
+        #expect(safe.contains("corrupt") || safe.contains("supported"))
+        #expect(!safe.contains("0x148e042e0"))
+        #expect(!safe.contains("moov atom"))
+    }
 }


### PR DESCRIPTION
## Summary

\`YTDLPError\` and \`FfmpegError\` now sanitize stderr at the error type level. \`errorDescription\` (which the UI consumes via \`error.localizedDescription\`) maps ~15 known stderr patterns to short user-safe messages and falls back to a generic message for everything else. Raw stderr is preserved only on a new \`internalDetail\` property for developer logging.

### Leaks before this PR
- Absolute file paths (\`/Users/<username>/...\`)
- Cookie file paths
- Hostnames from network errors
- Auth tokens in URLs
- Python tracebacks with module paths
- Internal yt-dlp/ffmpeg module identifiers
- Hex pointers from ffmpeg

### Patterns mapped to friendly messages
- DNS / network unreachable / connection refused / SSL handshake
- HTTP 403 / 404 / 429 / 5xx
- Video unavailable / removed / private / members-only
- Age-restricted / sign-in required
- Geo-blocked
- Unsupported URL
- Live stream / premiere not started
- Copyright restrictions
- ffmpeg: file not found / permission denied / corrupt input / encoder/decoder missing / out of disk

### Test plan
- [x] \`xcodebuild build\` — BUILD SUCCEEDED
- [x] \`xcodebuild test\` — **47/47 pass** (was 36, added 11)
- [x] New tests verify: paths, hostnames, tracebacks NEVER appear in errorDescription; each known category maps correctly; unknown stderr falls back without echoing
- [x] internalDetail preserves raw text for developer logs

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)