### PR TITLE
fix: notarization pipeline — build-release + package-dmg + notarize-dmg scripts

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# build-release.sh — produces a notarization-ready signed Release build of Fetch.app
+#
+# Output: ./release-build/Release/Fetch.app (signed, hardened, timestamped)
+#
+# Usage: ./scripts/build-release.sh
+#
+# Requirements:
+#   - Xcode + xcodebuild
+#   - xcodegen (brew install xcodegen)
+#   - "Developer ID Application: Matthew Rogers (69LXV4BEHY)" certificate in Keychain
+#
+# Why each flag matters (Apple notarization service requirements):
+#   - CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO
+#       xcodebuild defaults to injecting `com.apple.security.get-task-allow=true`
+#       into the signed binary regardless of configuration. This entitlement
+#       lets debuggers attach and is REJECTED by Apple's notary service.
+#       Setting this to NO suppresses the injection.
+#   - OTHER_CODE_SIGN_FLAGS="--timestamp --options runtime"
+#       --timestamp: embeds an Apple-issued secure timestamp (required by notary)
+#       --options runtime: enables hardened runtime (also required by notary)
+#       Both are belt-and-suspenders even though ENABLE_HARDENED_RUNTIME=YES
+#       is set in project.yml.
+#   - CODE_SIGN_STYLE=Manual + CODE_SIGN_IDENTITY=...
+#       Forces a specific Developer ID certificate, no automatic provisioning.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+CERT="Developer ID Application: Matthew Rogers (69LXV4BEHY)"
+TEAM_ID="69LXV4BEHY"
+BUILD_DIR="$REPO_ROOT/release-build"
+
+echo "==> Regenerating Xcode project from project.yml"
+xcodegen generate
+
+echo ""
+echo "==> Building Release with Developer ID signing + timestamp + hardened runtime"
+xcodebuild \
+    -project Fetch.xcodeproj \
+    -scheme Fetch \
+    -configuration Release \
+    -destination 'platform=macOS' \
+    SYMROOT="$BUILD_DIR" \
+    CODE_SIGN_STYLE=Manual \
+    CODE_SIGN_IDENTITY="$CERT" \
+    DEVELOPMENT_TEAM="$TEAM_ID" \
+    CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
+    OTHER_CODE_SIGN_FLAGS="--timestamp --options runtime" \
+    clean build
+
+APP_PATH="$BUILD_DIR/Release/Fetch.app"
+
+echo ""
+echo "==> Verifying signature"
+codesign -dvvv "$APP_PATH" 2>&1 | grep -E '(Authority|Identifier|TeamIdentifier|Runtime|Timestamp|Signed Time)'
+
+echo ""
+echo "==> Checking entitlements (must NOT include get-task-allow)"
+# Capture into a variable to avoid `pipefail` + `grep -q` SIGPIPE issues:
+# `grep -q` exits early on match, closes the pipe, codesign gets SIGPIPE,
+# pipefail propagates the non-zero exit even though grep matched correctly.
+ENTITLEMENTS=$(codesign -d --entitlements - "$APP_PATH" 2>&1)
+if echo "$ENTITLEMENTS" | grep -q "get-task-allow"; then
+    echo "ERROR: get-task-allow entitlement is present — notarization will fail"
+    echo "$ENTITLEMENTS"
+    exit 1
+fi
+echo "OK — no get-task-allow"
+
+echo ""
+echo "==> Verifying secure timestamp"
+# codesign output uses "Timestamp=" for the secure timestamp.
+# "Signed Time=" appears only on ad-hoc / non-timestamped signatures.
+SIG_INFO=$(codesign -dvvv "$APP_PATH" 2>&1)
+if ! echo "$SIG_INFO" | grep -q "^Timestamp="; then
+    echo "ERROR: secure timestamp missing — notarization will fail"
+    echo "$SIG_INFO" | grep -iE "time"
+    exit 1
+fi
+echo "OK — secure timestamp present"
+
+echo ""
+echo "==> Build complete: $APP_PATH"
+echo "    Next step: ./scripts/package-dmg.sh"

--- a/scripts/notarize-dmg.sh
+++ b/scripts/notarize-dmg.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# notarize-dmg.sh — submits a signed DMG to Apple's notary service, waits, staples, verifies
+#
+# Usage: ./scripts/notarize-dmg.sh path/to/Fetch.dmg
+#
+# Requirements:
+#   - "fetch-notary" keychain profile (one-time setup):
+#       xcrun notarytool store-credentials "fetch-notary" \
+#           --apple-id "your-apple-id@example.com" \
+#           --team-id "69LXV4BEHY"
+#   - DMG must be signed with Developer ID + secure timestamp + hardened runtime
+#     (use scripts/build-release.sh + scripts/package-dmg.sh)
+#
+# What this does:
+#   1. Submit DMG to Apple notary service (--wait blocks until result)
+#   2. If accepted, staple the notarization ticket to the DMG so it works offline
+#   3. Verify the staple worked
+#   4. Verify Gatekeeper accepts it via spctl
+
+set -euo pipefail
+
+DMG="${1:?usage: notarize-dmg.sh path/to/Fetch.dmg}"
+PROFILE="fetch-notary"
+
+if [ ! -f "$DMG" ]; then
+    echo "ERROR: $DMG not found"
+    exit 1
+fi
+
+echo "==> Submitting $DMG to Apple notary service (this takes 5-15 minutes)"
+SUBMIT_OUTPUT=$(xcrun notarytool submit "$DMG" \
+    --keychain-profile "$PROFILE" \
+    --wait 2>&1)
+echo "$SUBMIT_OUTPUT"
+
+# Extract status from output
+STATUS=$(echo "$SUBMIT_OUTPUT" | grep -E "^\s*status:" | tail -1 | awk '{print $2}')
+SUBMISSION_ID=$(echo "$SUBMIT_OUTPUT" | grep -E "^\s*id:" | head -1 | awk '{print $2}')
+
+if [ "$STATUS" != "Accepted" ]; then
+    echo ""
+    echo "ERROR: notarization status is '$STATUS' (expected 'Accepted')"
+    echo ""
+    echo "==> Fetching notarization log for diagnosis"
+    xcrun notarytool log "$SUBMISSION_ID" --keychain-profile "$PROFILE"
+    exit 1
+fi
+
+echo ""
+echo "==> Stapling notarization ticket to DMG"
+xcrun stapler staple "$DMG"
+
+echo ""
+echo "==> Validating staple"
+xcrun stapler validate "$DMG"
+
+echo ""
+echo "==> Verifying with Gatekeeper (spctl)"
+spctl -a -t open --context context:primary-signature -v "$DMG"
+
+echo ""
+echo "==> Notarized DMG ready: $DMG"
+ls -lh "$DMG"

--- a/scripts/package-dmg.sh
+++ b/scripts/package-dmg.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# package-dmg.sh — packages a signed Release build into a signed DMG
+#
+# Output: ./release-build/Fetch-vX.Y.Z-macOS.dmg
+#
+# Usage: ./scripts/package-dmg.sh [version]
+#   version defaults to MARKETING_VERSION from Info.plist
+#
+# Requirements:
+#   - ./release-build/Release/Fetch.app must exist (run build-release.sh first)
+#   - "Developer ID Application: Matthew Rogers (69LXV4BEHY)" certificate
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+CERT="Developer ID Application: Matthew Rogers (69LXV4BEHY)"
+APP_PATH="release-build/Release/Fetch.app"
+
+if [ ! -d "$APP_PATH" ]; then
+    echo "ERROR: $APP_PATH not found. Run scripts/build-release.sh first."
+    exit 1
+fi
+
+VERSION="${1:-$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PATH/Contents/Info.plist")}"
+DMG_NAME="Fetch-v${VERSION}-macOS.dmg"
+DMG_PATH="release-build/$DMG_NAME"
+STAGING="/tmp/fetch-dmg-staging-$$"
+
+echo "==> Building DMG for version $VERSION"
+
+# Stage the .app + Applications symlink
+rm -rf "$STAGING"
+mkdir -p "$STAGING"
+cp -R "$APP_PATH" "$STAGING/"
+ln -s /Applications "$STAGING/Applications"
+
+# Build the DMG
+rm -f "$DMG_PATH"
+hdiutil create \
+    -volname "Fetch ${VERSION}" \
+    -srcfolder "$STAGING" \
+    -ov -format UDZO \
+    "$DMG_PATH"
+
+rm -rf "$STAGING"
+
+echo ""
+echo "==> Signing DMG with timestamp"
+codesign \
+    --sign "$CERT" \
+    --timestamp \
+    "$DMG_PATH"
+
+echo ""
+echo "==> Verifying DMG signature"
+codesign -dvvv "$DMG_PATH" 2>&1 | grep -E '(Authority|Identifier|Signed Time|Timestamp)'
+
+echo ""
+echo "==> DMG ready: $DMG_PATH"
+ls -lh "$DMG_PATH"
+echo ""
+echo "    Next step: ./scripts/notarize-dmg.sh $DMG_PATH"


### PR DESCRIPTION
## Summary

Apple's notary service rejected the initial v0.2.1-beta.1 DMG with two critical errors:
1. **Missing secure timestamp** — codesign wasn't passing \`--timestamp\`
2. **\`get-task-allow\` entitlement present** — xcodebuild auto-injects this debug entitlement unless explicitly suppressed

Fixed by introducing three scripts that document the correct incantation:

### scripts/build-release.sh
Builds the Release configuration with:
- \`CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO\` — suppresses auto-injection of \`get-task-allow\`
- \`OTHER_CODE_SIGN_FLAGS="--timestamp --options runtime"\` — secure timestamp + hardened runtime
- Post-build verification that fails loudly if either requirement is missing

### scripts/package-dmg.sh
Stages the .app + Applications symlink, runs \`hdiutil create\`, signs the DMG with \`--timestamp\`.

### scripts/notarize-dmg.sh
Submits the DMG to Apple's notary service, waits for the result, staples the ticket if accepted, verifies with \`spctl\`. Fetches the rejection log automatically if Apple rejects.

## Pipefail gotcha found during development

\`codesign | grep -q "pattern"\` causes grep to exit 0 on first match, which closes the pipe, which sends SIGPIPE to codesign, which returns non-zero, which \`set -o pipefail\` propagates as a false negative. The fix is to capture codesign output into a variable first, then grep the variable. Documented in the script comments so future readers don't re-discover it.

## Test plan
- [x] \`./scripts/build-release.sh\` — BUILD SUCCEEDED, verification passes
- [x] \`./scripts/package-dmg.sh 0.2.1-beta.1\` — 2.3 MB signed DMG
- [ ] \`./scripts/notarize-dmg.sh release-build/Fetch-v0.2.1-beta.1-macOS.dmg\` — in progress in parallel, will update when complete

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)