### PR TITLE
ci: add macOS build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build and test on macOS 15
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.app || sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Cache Homebrew
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/Homebrew
+            /opt/homebrew/Cellar/xcodegen
+            /opt/homebrew/Cellar/yt-dlp
+          key: brew-${{ runner.os }}-${{ hashFiles('.github/workflows/ci.yml') }}
+          restore-keys: |
+            brew-${{ runner.os }}-
+
+      - name: Install xcodegen and yt-dlp via Homebrew
+        run: |
+          set -o pipefail
+          brew install xcodegen yt-dlp
+
+      - name: Generate Xcode project
+        run: |
+          set -o pipefail
+          xcodegen generate
+
+      - name: Build (Debug)
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project Fetch.xcodeproj \
+            -scheme Fetch \
+            -configuration Debug \
+            -destination 'platform=macOS' \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
+      - name: Test
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project Fetch.xcodeproj \
+            -scheme FetchTests \
+            -destination 'platform=macOS' \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            test

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <h1 align="center">Fetch</h1>
 
 <p align="center">
+  <a href="https://github.com/twitchyvr/Fetch/actions/workflows/ci.yml"><img src="https://github.com/twitchyvr/Fetch/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/License-AGPL_v3-blue.svg" alt="License: AGPL v3"></a>
   <a href="https://developer.apple.com/macos/"><img src="https://img.shields.io/badge/macOS-15%2B-brightgreen" alt="macOS 15+"></a>
   <a href="https://swift.org"><img src="https://img.shields.io/badge/Swift-6-orange" alt="Swift 6"></a>


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/ci.yml\` that runs build + tests on every push to main and every PR targeting main. Runs on \`macos-15\` to match the deployment target.

### Steps
1. Checkout
2. Select Xcode
3. Cache Homebrew
4. Install \`xcodegen\` + \`yt-dlp\` via Homebrew (yt-dlp needed because \`YTDLPServiceTests\` actually invokes the binary)
5. \`xcodegen generate\`
6. Build (Debug, ad-hoc signing)
7. Test (Debug, ad-hoc signing)

### Security review
No untrusted user input (issue titles, PR bodies, commit messages, head refs, etc.) is interpolated into any \`run:\` command. The only \`${{ }}\` expressions are:
- \`github.ref\` in the concurrency group (metadata, not shell)
- \`runner.os\` in the cache key (metadata)
- \`hashFiles('.github/workflows/ci.yml')\` in the cache key (file content hash)

Per https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/.

### Test plan
- [x] YAML validates cleanly (\`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"\`)
- [ ] First CI run completes successfully (will verify after merge)

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)